### PR TITLE
added missing compset from featureCESM2.1.0-OsloDevelopment

### DIFF
--- a/bld/namelist_files/use_cases/2101-2300_SSP1-2.6_transient.xml
+++ b/bld/namelist_files/use_cases/2101-2300_SSP1-2.6_transient.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc            >Simulate transient land-use, and aerosol deposition changes from 1850 to current day with historical data, and then to 2100 with the CMIP6 SSP1-2.6 scenario</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to current day with historical data, and then to 2100 with the CMIP6 SSP1-2.6 scenario</use_case_desc>
+
+<!-- Have a minimal list of things set here, sim_year, sim_year_range, and ssp_rcp, other things should be dependent on these and
+     set in a namelist_defaults xml file -->
+
+<sim_year>1850</sim_year>
+
+<sim_year_range>2100-2300</sim_year_range>
+
+<ssp_rcp>SSP1-2.6</ssp_rcp>
+
+<clm_demand >flanduse_timeseries</clm_demand>
+
+</namelist_defaults>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -115,6 +115,7 @@
       <!--value compset="^RCP8_"		>1850-2100_rcp8.5_transient</value-->
       <value compset="^SSP585_"	                    >1850-2100_SSP5-8.5_transient</value>
       <value compset="^SSP126_"	                    >1850-2100_SSP1-2.6_transient</value>
+      <value compset="^SSP126_CAM60%NORESM%FRC2EXT" >2101-2300_SSP1-2.6_transient</value>
       <value compset="^SSP370_"	                    >1850-2100_SSP3-7.0_transient</value>
       <value compset="^SSP370LOWNTCF_"	            >1850-2100_SSP3-7.0_transient</value>
       <value compset="^SSP370REFGHGLOWNTCF_"	    >1850-2100_SSP3-7.0_transient</value>
@@ -127,6 +128,12 @@
       <value compset="^SSP585_CAM60%NORESM%FRC2EXT" >2101-2300_SSP5-8.5_transient</value>
       <value compset="^AMIP_"		>20thC_transient</value>
       <value compset="^PIPD_"           >1850-2100_rcp4.5_transient</value>
+
+      <value compset="^SSP245_CAM60%NORESM%NORPIBC%GHGONLY" >1850_control</value>
+      <value compset="^SSP245_CAM60%NORESM%NORPIBC%NATONLY" >1850_control</value>
+      <value compset="^SSP245_CAM60%NORESM%NORPIBC%AERONLY" >1850_control</value>
+      <value compset="^SSP245_CAM60%NORESM%NORPIBC%AEROXIDONLY" >1850_control</value>
+
     </values>
     <group>run_component_clm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
### Description of changes
Some compsets used for CMIP6 (in the old repository branch=featureCESM2.1.0-OsloDevelopment) were not yet taken over into the new distributed repository structure.  This pull request aims to include these missing compsets also in the new structure.  It implies two small changes in CTSM: 
- config_component.xml for CTSM is modified
- bld/namelist_files/use_cases/2101-2300_SSP1-2.6_transient.xml is new

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)? No.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any: No.
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
