### PR TITLE
Allow for global 0.125 deg ocean configuration

### DIFF
--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1805,7 +1805,7 @@ hist means do NOT use a future scenario, just use historical data.
 
 <entry id="mask" type="char*10" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,gx1v7,navy,test,tx0.1v2,tx1v1,T62,cruncep,tnx1v1,tnx0.25v1,tnx0.25v3,tnx0.25v4,tnx1v4,tnx1v3">
+       valid_values="USGS,gx3v7,gx1v6,gx1v7,navy,test,tx0.1v2,tx1v1,T62,cruncep,tnx1v1,tnx0.25v1,tnx0.25v3,tnx0.25v4,tnx0.125v4,tnx1v4,tnx1v3">
 Land mask description
 </entry> 
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -231,7 +231,7 @@ def buildnml(case, caseroot, compname):
         create_namelist_infile(case, user_nl_file, namelist_infile, "\n".join(infile_lines))
 
         cmd = os.path.join(lnd_root,"bld","build-namelist")
-        if ocn_grid == "tnx1v1" or ocn_grid == "tnx0.25v1" or ocn_grid == "tnx1v3" or ocn_grid == "tnx1v4" or ocn_grid == "tnx0.25v3" or ocn_grid == "tnx0.25v4":
+        if ocn_grid == "tnx1v1" or ocn_grid == "tnx0.25v1" or ocn_grid == "tnx1v3" or ocn_grid == "tnx1v4" or ocn_grid == "tnx0.25v3" or ocn_grid == "tnx0.25v4" or ocn_grid == "tnx0.125v4":
             command = ("%s -cimeroot %s -infile %s -csmdata %s -inputdata %s %s -namelist \"&clm_inparm  start_ymd=%s %s/ \" "
                    "%s %s -res %s %s -clm_start_type %s -envxml_dir %s -l_ncpl %s "
                    "-lnd_frac %s -glc_nec %s -co2_ppmv %s -co2_type %s -config %s "


### PR DESCRIPTION
This pull request introduces the BLOM 1/8 deg (tnx0125) to NorESM, companion pull requests are made to other components. For CLM we only edit namelist definitions.

Tested configurations: N1850frc2NOECO_f09_tnx0125v4, NOINY_T62_tn01254

!Note! from the companion CIME pull request: to run on Betzy, one also needs to change either config/cesm/machines/config_compilers.xml or Macros.make in a case folder, so that FFLAGS includes: -mcmodel medium option.
