### PR TITLE
Fix apply_use_init_interp() use in branch run

### DIFF
--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -1007,7 +1007,7 @@ contains
     !-----------------------------------------------------------------------
 
     if (finidat == ' ') then
-       call endrun(msg=' ERROR: Can only set use_init_interp if finidat is set')
+       write(iulog,*)' WARNING: Setting use_init_interp has no effect if finidat is not also set'
     end if
 
     if (finidat_interp_source /= ' ') then


### PR DESCRIPTION
Fix issue of
https://github.com/ESCOMP/CTSM/issues/786
Allow apply_use_init_interp() in branch run.