### PR TITLE
update externals and config_pes for betzy

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_noresm0.0.3
+tag = ccs_config_noresm0.0.5
 protocol = git
 repo_url = https://github.com/NorESMhub/ccs_config_noresm.git
 local_path = ccs_config

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1379,14 +1379,14 @@
       <pes pesize="any" compset="any">
 	<comment>Need at least 4 nodes to default to normal queue</comment>
 	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm> 
-	  <ntasks_lnd>-4</ntasks_lnd>           
-	  <ntasks_rof>-4</ntasks_rof> 
-	  <ntasks_ice>-4</ntasks_ice> 
-	  <ntasks_ocn>-4</ntasks_ocn> 
-	  <ntasks_glc>-4</ntasks_glc> 
-	  <ntasks_wav>-4</ntasks_wav> 
-	  <ntasks_cpl>-4</ntasks_cpl> 
+	  <ntasks_atm>-1</ntasks_atm> 
+	  <ntasks_lnd>-3</ntasks_lnd>           
+	  <ntasks_rof>-3</ntasks_rof> 
+	  <ntasks_ice>-3</ntasks_ice> 
+	  <ntasks_ocn>-3</ntasks_ocn> 
+	  <ntasks_glc>-3</ntasks_glc> 
+	  <ntasks_wav>-3</ntasks_wav> 
+	  <ntasks_cpl>-3</ntasks_cpl> 
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>                   
@@ -1400,13 +1400,50 @@
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_lnd>-3</rootpe_lnd> 
+	  <rootpe_rof>-3</rootpe_rof> 
+	  <rootpe_ice>-3</rootpe_ice>    
+	  <rootpe_ocn>-3</rootpe_ocn>   
+	  <rootpe_glc>-3</rootpe_glc> 
+	  <rootpe_wav>-3</rootpe_wav> 
+	  <rootpe_cpl>-3</rootpe_cpl>                         
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%1.9x2.5|l%0.9x1.25">
+    <mach name="betzy">
+      <pes pesize="M" compset="any">
+	<comment>Need at least 4 nodes to default to normal queue</comment>
+	<ntasks>
+	  <ntasks_atm>-1</ntasks_atm> 
+	  <ntasks_lnd>-7</ntasks_lnd>           
+	  <ntasks_rof>-7</ntasks_rof> 
+	  <ntasks_ice>-7</ntasks_ice> 
+	  <ntasks_ocn>-7</ntasks_ocn> 
+	  <ntasks_glc>-7</ntasks_glc> 
+	  <ntasks_wav>-7</ntasks_wav> 
+	  <ntasks_cpl>-7</ntasks_cpl> 
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>                   
+	  <nthrds_lnd>1</nthrds_lnd> 
+	  <nthrds_rof>1</nthrds_rof> 
+	  <nthrds_ice>1</nthrds_ice> 
+	  <nthrds_ocn>1</nthrds_ocn> 
+	  <nthrds_glc>1</nthrds_glc> 
+	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_cpl>1</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm> 
+	  <rootpe_lnd>-1</rootpe_lnd> 
+	  <rootpe_rof>-1</rootpe_rof> 
+	  <rootpe_ice>-1</rootpe_ice>    
+	  <rootpe_ocn>-1</rootpe_ocn>   
+	  <rootpe_glc>-1</rootpe_glc> 
+	  <rootpe_wav>-1</rootpe_wav> 
+	  <rootpe_cpl>-1</rootpe_cpl>                         
 	</rootpe>
       </pes>
     </mach>


### PR DESCRIPTION
### Description of changes

After testing, best performance and scaling are found when DATM uses only 1 node. 
Also, added pesize M for betzy to easily checkout 8 node configuration.


### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
