### PR TITLE
Nbp nobalancecheck

### DIFF
--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -463,13 +463,10 @@ contains
             ! Total land carbon is informed by FATES carbon. 
             grc_endcb(g) = totgrcc(g) + tot_woodprod_grc(g) + cropprod1_grc(g)
             
+            grc_cinputs = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g)
 
-            nbp_grc(g)  = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g)-soilbiogeochem_carbonflux_inst%hr_col(c)
-            
-            grc_cinputs = nbp_grc(g)
-            grc_cinputs = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g) !newr calc
-            ! removing the hr_col here as it is 0 in the clmfates_interface, but not in the summary
             grc_coutputs = - som_c_leached_grc(g)
+
             grc_errcb(g) = (grc_cinputs - grc_coutputs) * dt - &
                  (grc_endcb(g) - grc_begcb(g))
          end if

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -306,14 +306,20 @@ contains
          if( col%is_fates(c) ) then
 
             s = clm_fates%f2hmap(ic)%hsites(c)
+            ! this balance check previously only had the soil as its boundary condition
+            ! but was passing the totcolc as the beg/end state varialbe.
+            ! and this contains the vegetation carbon
+
+            ! is there anything we can say at the column level if harvest is exported? 
+            ! think it might be best to bypass this check for now... 
             
-            col_cinputs = fates_litter_flux(c)
-            
+            col_cinputs = fates_litter_flux(c)+soilbiogeochem_carbonflux_inst%fates_nep_col(c)
             ! calculate total column-level outputs
             ! fates has already exported burn losses and fluxes to the atm
             ! So they are irrelevant here
             ! (gC/m2/s) total heterotrophic respiration
             col_coutputs = soilbiogeochem_carbonflux_inst%hr_col(c)
+
 
          else
             
@@ -349,13 +355,13 @@ contains
             err_found = .true.
             err_index = c
          end if
-          if (abs(col_errcb(c)) > this%cwarning) then
+          if (abs(col_errcb(c)) > this%cwarning.and. .not.use_fates_bgc) then
             write(iulog,*) 'cbalance warning at c =', c, col_errcb(c), col_endcb(c)
          end if
 
-      end do ! end of columns loop
+!      end do ! end of columns loop
 
-      if (err_found) then
+      if (err_found.and. .not.use_fates_bgc) then
          c = err_index
          write(iulog,*)'column cbalance error    = ', col_errcb(c), c
          write(iulog,*)'is fates column?         = ', col%is_fates(c)
@@ -383,6 +389,9 @@ contains
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt
          call endrun(subgrid_index=c, subgrid_level=subgrid_level_column, msg=errMsg(sourcefile, __LINE__))
       end if
+    end do ! end of columns loop                                                                      
+
+
 
       ! Repeat error check at the gridcell level
       call c2g( bounds = bounds, &
@@ -390,17 +399,28 @@ contains
          garr = totgrcc(bounds%begg:bounds%endg), &
          c2l_scale_type = 'unity', &
          l2g_scale_type = 'unity')
+      write(*,*) 'totc',totcolc(bounds%begc:bounds%endc)
+      write(*,*) 'totg',totgrcc(bounds%begg:bounds%endg)
+      write(*,*) 'lats', grc%latdeg(bounds%begg:bounds%endg)
+
       call c2g( bounds = bounds, &
          carr = som_c_leached(bounds%begc:bounds%endc), &
          garr = som_c_leached_grc(bounds%begg:bounds%endg), &
          c2l_scale_type = 'unity', &
          l2g_scale_type = 'unity')
 
+      if(use_fates_bgc)then
+         call c2g( bounds = bounds, &
+         carr = soilbiogeochem_carbonflux_inst%fates_nbp_col(bounds%begc:bounds%endc), &
+         garr = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds%endg), &
+         c2l_scale_type = 'unity', &
+         l2g_scale_type = 'unity')         
+      end if
+write(*,*) 'nbp',soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds%endg)      
       err_found = .false.
       do g = bounds%begg, bounds%endg
          ! calculate gridcell-level carbon storage for mass conservation check
-         ! Notes:
-         ! totgrcc = totcolc = totc_p2c_col(c) + soilbiogeochem_cwdc_col(c) + soilbiogeochem_totlitc_col(c) + soilbiogeochem_totmicc_col(c) + soilbiogeochem_totsomc_col(c) + soilbiogeochem_ctrunc_col(c)
+         ! Notes: totgrcc = totcolc = totc_p2c_col(c) + soilbiogeochem_cwdc_col(c) + soilbiogeochem_totlitc_col(c) + soilbiogeochem_totmicc_col(c) + soilbiogeochem_totsomc_col(c) + soilbiogeochem_ctrunc_col(c)
          ! totc_p2c_col = totc_patch = totvegc_patch(p) + xsmrpool_patch(p) + ctrunc_patch(p) + cropseedc_deficit_patch(p)
          ! Not including seedc_grc in grc_begcb and grc_endcb because
          ! seedc_grc forms out of thin air, for now, and equals
@@ -439,26 +459,38 @@ contains
             
          else
             
-            ! Totally punt on this for now. We just don't track these gridscale variables yet (RGK)
-            grc_cinputs  = 0._r8
-            grc_endcb(g) = grc_begcb(g)
-            grc_coutputs = 0._r8
-            grc_errcb(g) = 0._r8
+            ! FATES gridcell level balance check.
+            ! Inputs are calculated from the fates_nbp
+            ! Outputs the same as for cn mode.
+            ! Total land carbon is informed by FATES carbon. 
+            grc_endcb(g) = totgrcc(g) + tot_woodprod_grc(g) + cropprod1_grc(g)
             
+
+            nbp_grc(g)  = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g)-soilbiogeochem_carbonflux_inst%hr_col(c)
+            
+            grc_cinputs = nbp_grc(g)
+            grc_cinputs = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g) !newr calc
+            ! removing the hr_col here as it is 0 in the clmfates_interface, but not in the summary
+            grc_coutputs = - som_c_leached_grc(g)
+            write(*,*) 'nbp int, nbp prev',nbp_grc(g)  ,soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds%endg)
+            grc_errcb(g) = (grc_cinputs - grc_coutputs) * dt - &
+                 (grc_endcb(g) - grc_begcb(g))
+            write(*,*) 'GCELL error:',g,grc_errcb(g)
+            write(*,*) 'GCELL error:' ,grc_endcb(g) - grc_begcb(g),(grc_cinputs - grc_coutputs) * dt
          end if
          
          ! check for significant errors
          if (abs(grc_errcb(g)) > this%cerror) then
             err_found = .true.
             err_index = g
+            write(*,*) 'error found',g,  grc_errcb(g)
          end if
          if (abs(grc_errcb(g)) > this%cwarning) then
-            write(iulog,*) 'cbalance warning at g =', g, grc_errcb(g), grc_endcb(g)
+            write(iulog,*) 'cbal warning:', g, grc_errcb(g), grc_endcb(g)
          end if
-      end do ! end of gridcell loop
 
       if (err_found) then
-         g = err_index
+         !g = err_index
          write(iulog,*)'gridcell cbalance error =', grc_errcb(g), g
          write(iulog,*)'latdeg, londeg          =', grc%latdeg(g), grc%londeg(g)
          write(iulog,*)'begcb                   =', grc_begcb(g)
@@ -472,7 +504,10 @@ contains
          write(iulog,*)'-1*som_c_leached_grc    = ', som_c_leached_grc(g) * dt
          call endrun(subgrid_index=g, subgrid_level=subgrid_level_gridcell, msg=errMsg(sourcefile, __LINE__))
       end if
-
+      
+      ! moving the update until after the error report. 
+      grc_endcb(g) = grc_begcb(g)      
+    end do !
     end associate
 
   end subroutine CBalanceCheck

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -204,6 +204,9 @@ contains
        c = filter_soilc(fc)
 
        col_begcb(c) = totcolc(c)
+       if(use_fates_bgc)then
+          col_begcb(c)= soilbiogeochem_carbonstate_inst%totsomc_col(c)
+       endif
        col_begnb(c) = totcoln(c)
 
     end do
@@ -304,23 +307,18 @@ contains
          
          
          if( col%is_fates(c) ) then
-
+            col_endcb(c) = soilbiogeochem_carbonstate_inst%totsomc_col(c) 
             s = clm_fates%f2hmap(ic)%hsites(c)
-            ! this balance check previously only had the soil as its boundary condition
-            ! but was passing the totcolc as the beg/end state varialbe.
-            ! and this contains the vegetation carbon
-
-            ! is there anything we can say at the column level if harvest is exported? 
-            ! think it might be best to bypass this check for now... 
             
-            col_cinputs = fates_litter_flux(c)+soilbiogeochem_carbonflux_inst%fates_nep_col(c)
-            ! calculate total column-level outputs
-            ! fates has already exported burn losses and fluxes to the atm
-            ! So they are irrelevant here
+            ! this balance check determines the column level balance of the soil pool 
+            ! when FATES is on. 
+            col_cinputs = fates_litter_flux(c)
+
+            ! calculate total column-level outputs from soil pool 
             ! (gC/m2/s) total heterotrophic respiration
+            ! what about leaching?
+            
             col_coutputs = soilbiogeochem_carbonflux_inst%hr_col(c)
-
-
          else
             
             ! calculate total column-level inputs
@@ -355,13 +353,14 @@ contains
             err_found = .true.
             err_index = c
          end if
-          if (abs(col_errcb(c)) > this%cwarning.and. .not.use_fates_bgc) then
-            write(iulog,*) 'cbalance warning at c =', c, col_errcb(c), col_endcb(c)
+          if (abs(col_errcb(c)) > this%cwarning) then
+             write(iulog,*) 'cbalance warning at c =', c, col_errcb(c), col_endcb(c)
+             write(iulog,*) 'flux, dstock',(col_cinputs - col_coutputs)*dt, (col_endcb(c) - col_begcb(c))
          end if
 
 !      end do ! end of columns loop
 
-      if (err_found.and. .not.use_fates_bgc) then
+      if (err_found) then
          c = err_index
          write(iulog,*)'column cbalance error    = ', col_errcb(c), c
          write(iulog,*)'is fates column?         = ', col%is_fates(c)
@@ -387,7 +386,9 @@ contains
             write(iulog,*)'hr                       = ',soilbiogeochem_carbonflux_inst%hr_col(c)*dt
          end if
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt
-         call endrun(subgrid_index=c, subgrid_level=subgrid_level_column, msg=errMsg(sourcefile, __LINE__))
+         if(.not. use_fates_bgc)then
+            call endrun(subgrid_index=c, subgrid_level=subgrid_level_column, msg=errMsg(sourcefile, __LINE__))
+         endif
       end if
     end do ! end of columns loop                                                                      
 
@@ -399,9 +400,6 @@ contains
          garr = totgrcc(bounds%begg:bounds%endg), &
          c2l_scale_type = 'unity', &
          l2g_scale_type = 'unity')
-      write(*,*) 'totc',totcolc(bounds%begc:bounds%endc)
-      write(*,*) 'totg',totgrcc(bounds%begg:bounds%endg)
-      write(*,*) 'lats', grc%latdeg(bounds%begg:bounds%endg)
 
       call c2g( bounds = bounds, &
          carr = som_c_leached(bounds%begc:bounds%endc), &
@@ -416,7 +414,7 @@ contains
          c2l_scale_type = 'unity', &
          l2g_scale_type = 'unity')         
       end if
-write(*,*) 'nbp',soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds%endg)      
+
       err_found = .false.
       do g = bounds%begg, bounds%endg
          ! calculate gridcell-level carbon storage for mass conservation check
@@ -472,18 +470,14 @@ write(*,*) 'nbp',soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds
             grc_cinputs = soilbiogeochem_carbonflux_inst%fates_nbp_grc(g) !newr calc
             ! removing the hr_col here as it is 0 in the clmfates_interface, but not in the summary
             grc_coutputs = - som_c_leached_grc(g)
-            write(*,*) 'nbp int, nbp prev',nbp_grc(g)  ,soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds%begg:bounds%endg)
             grc_errcb(g) = (grc_cinputs - grc_coutputs) * dt - &
                  (grc_endcb(g) - grc_begcb(g))
-            write(*,*) 'GCELL error:',g,grc_errcb(g)
-            write(*,*) 'GCELL error:' ,grc_endcb(g) - grc_begcb(g),(grc_cinputs - grc_coutputs) * dt
          end if
          
          ! check for significant errors
          if (abs(grc_errcb(g)) > this%cerror) then
             err_found = .true.
             err_index = g
-            write(*,*) 'error found',g,  grc_errcb(g)
          end if
          if (abs(grc_errcb(g)) > this%cwarning) then
             write(iulog,*) 'cbal warning:', g, grc_errcb(g), grc_endcb(g)

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -360,7 +360,7 @@ contains
 
 !      end do ! end of columns loop
 
-      if (err_found) then
+      if (err_found .and. .not. use_fates_bgc) then
          c = err_index
          write(iulog,*)'column cbalance error    = ', col_errcb(c), c
          write(iulog,*)'is fates column?         = ', col%is_fates(c)
@@ -483,7 +483,7 @@ contains
             write(iulog,*) 'cbal warning:', g, grc_errcb(g), grc_endcb(g)
          end if
 
-      if (err_found) then
+         if (err_found .and. .not. use_fates_bgc) then
          !g = err_index
          write(iulog,*)'gridcell cbalance error =', grc_errcb(g), g
          write(iulog,*)'latdeg, londeg          =', grc%latdeg(g), grc%londeg(g)

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -353,7 +353,7 @@ contains
             err_found = .true.
             err_index = c
          end if
-          if (abs(col_errcb(c)) > this%cwarning) then
+          if (abs(col_errcb(c)) > this%cwarning .and. .not. use_fates_bgc) then
              write(iulog,*) 'cbalance warning at c =', c, col_errcb(c), col_endcb(c)
              write(iulog,*) 'flux, dstock',(col_cinputs - col_coutputs)*dt, (col_endcb(c) - col_begcb(c))
          end if
@@ -476,7 +476,7 @@ contains
             err_found = .true.
             err_index = g
          end if
-         if (abs(grc_errcb(g)) > this%cwarning) then
+         if (abs(grc_errcb(g)) > this%cwarning .and. .not. use_fates_bgc ) then
             write(iulog,*) 'cbal warning:', g, grc_errcb(g), grc_endcb(g)
          end if
 
@@ -675,7 +675,7 @@ contains
             err_index = c
          end if
          
-         if (abs(col_errnb(c)) > this%nwarning) then
+         if (abs(col_errnb(c)) > this%nwarning ) then
             write(iulog,*) 'nbalance warning at c =', c, col_errnb(c), col_endnb(c)
             write(iulog,*)'inputs,ffix,nfix,ndep = ',ffix_to_sminn(c)*dt,nfix_to_sminn(c)*dt,ndep_to_sminn(c)*dt
             write(iulog,*)'outputs,lch,roff,dnit = ',smin_no3_leached(c)*dt, smin_no3_runoff(c)*dt,f_n2o_nit(c)*dt

--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -908,7 +908,8 @@ contains
     if (use_c13) call c13_products_inst%ComputeSummaryVars(bounds)
     if (use_c14) call c14_products_inst%ComputeSummaryVars(bounds)
     call n_products_inst%ComputeSummaryVars(bounds)
-    
+
+    ! unsure where else to put this - it can't go in the summary as that is all column variables. 
     soilbiogeochem_carbonflux_inst%fates_product_loss_grc(bounds%begg:bounds%endg)=c_products_inst%product_loss_grc(bounds%begg:bounds%endg)
     
     call t_stopf('CNWoodProducts')
@@ -1263,7 +1264,7 @@ contains
     ! ----------------------------------------------
     ! soilbiogeochem carbon/nitrogen flux summary
     ! ----------------------------------------------
-
+    
     call soilbiogeochem_carbonflux_inst%Summary(bounds, num_bgc_soilc, filter_bgc_soilc, &
          num_bgc_vegp, filter_bgc_vegp, &
          soilbiogeochem_carbonflux_inst%decomp_cascade_ctransfer_col(begc:endc,1:ndecomp_cascade_transitions), &

--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -860,6 +860,7 @@ contains
     end if
 
     if_bgc_vegp2: if(num_bgc_vegp>0)then
+
        call c_products_inst%UpdateProducts(bounds, &
             num_bgc_vegp, filter_bgc_vegp, &
             dwt_wood_product_gain_patch = cnveg_carbonflux_inst%dwt_wood_productc_gain_patch(begp:endp), &
@@ -903,11 +904,12 @@ contains
     if (use_c14) call c14_products_inst%ComputeProductSummaryVars(bounds)
     call n_products_inst%ComputeProductSummaryVars(bounds)
 
-
     call c_products_inst%ComputeSummaryVars(bounds)
     if (use_c13) call c13_products_inst%ComputeSummaryVars(bounds)
     if (use_c14) call c14_products_inst%ComputeSummaryVars(bounds)
     call n_products_inst%ComputeSummaryVars(bounds)
+    
+    soilbiogeochem_carbonflux_inst%fates_product_loss_grc(bounds%begg:bounds%endg)=c_products_inst%product_loss_grc(bounds%begg:bounds%endg)
     
     call t_stopf('CNWoodProducts')
        

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -250,6 +250,7 @@ contains
        call this%CNReadNML( NLFilename )    ! MUST be called first as passes down control information to others
     end if
 
+    
     if(use_cn.or.use_fates_bgc)then
        call this%cnveg_carbonstate_inst%Init(bounds, carbon_type='c12', ratio=1._r8, &
             NLFilename=NLFilename, dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm, &
@@ -1061,7 +1062,8 @@ contains
        soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst, &
        c13_soilbiogeochem_carbonflux_inst, c13_soilbiogeochem_carbonstate_inst, &
        c14_soilbiogeochem_carbonflux_inst, c14_soilbiogeochem_carbonstate_inst, &
-       soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst,c_products_inst)
+       soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst,c_products_inst,&
+       clm_fates)
     !
     ! !DESCRIPTION:
     ! Do the main science for CN vegetation that needs to be done after hydrology-drainage
@@ -1101,7 +1103,8 @@ contains
     type(soilbiogeochem_nitrogenflux_type)  , intent(inout) :: soilbiogeochem_nitrogenflux_inst
     type(soilbiogeochem_nitrogenstate_type) , intent(inout) :: soilbiogeochem_nitrogenstate_inst
      type(cn_products_type)                 , intent(inout) :: c_products_inst    
-    !
+    type(hlm_fates_interface_type)          , intent(inout) :: clm_fates
+     !
     ! !LOCAL VARIABLES:
 
     character(len=*), parameter :: subname = 'EcosystemDynamicsPostDrainage'
@@ -1172,6 +1175,8 @@ contains
          soilbiogeochem_nitrogenstate_inst, &
          soilbiogeochem_nitrogenflux_inst)
 
+
+       
     ! On the radiation time step, use C state variables to calculate
     ! vegetation structure (LAI, SAI, height)
     if(num_bgc_vegp>0)then
@@ -1181,6 +1186,11 @@ contains
                crop_inst, this%cnveg_carbonstate_inst, canopystate_inst)
        end if
     end if
+
+    if(use_fates_bgc)then
+      call clm_fates%wrap_AtmosphericCarbonFluxes(bounds,soilbiogeochem_carbonflux_inst,this%cnveg_carbonflux_inst,c_products_inst)
+    endif
+
     
   end subroutine EcosystemDynamicsPostDrainage
 
@@ -1217,6 +1227,7 @@ contains
     character(len=*), parameter :: subname = 'BalanceCheck'
     !-----------------------------------------------------------------------
 
+    
     DA_nstep = get_nstep_since_startup_or_lastDA_restart_or_pause()
     if (DA_nstep <= skip_steps )then
        if (masterproc) then

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -913,7 +913,7 @@ contains
          garr = soilbiogeochem_carbonstate_inst%totc_grc(bounds%begg:bounds%endg), &
          c2l_scale_type = 'unity', &
          l2g_scale_type = 'unity')
-    
+
     ! total gridcell nitrogen (TOTGRIDCELLN)
     call c2g( bounds = bounds, &
          carr = soilbiogeochem_nitrogenstate_inst%totn_col(bounds%begc:bounds%endc), &
@@ -1144,6 +1144,10 @@ contains
          c14_soilbiogeochem_carbonstate_inst,soilbiogeochem_nitrogenstate_inst)
     call t_stopf('SoilBiogeochemPrecisionControl')
 
+    if(use_fates_bgc)then
+      call clm_fates%wrap_AtmosphericCarbonFluxes(bounds,soilbiogeochem_carbonflux_inst,soilbiogeochem_carbonstate_inst)
+    endif
+    
     ! Call to all CN summary routines
     call CNDriverSummarizeStates(bounds, &
          num_allc, filter_allc, &
@@ -1186,10 +1190,6 @@ contains
                crop_inst, this%cnveg_carbonstate_inst, canopystate_inst)
        end if
     end if
-
-    if(use_fates_bgc)then
-      call clm_fates%wrap_AtmosphericCarbonFluxes(bounds,soilbiogeochem_carbonflux_inst,soilbiogeochem_carbonstate_inst)
-    endif
 
     
   end subroutine EcosystemDynamicsPostDrainage

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -1061,7 +1061,7 @@ contains
        soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst, &
        c13_soilbiogeochem_carbonflux_inst, c13_soilbiogeochem_carbonstate_inst, &
        c14_soilbiogeochem_carbonflux_inst, c14_soilbiogeochem_carbonstate_inst, &
-       soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst)
+       soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst,c_products_inst)
     !
     ! !DESCRIPTION:
     ! Do the main science for CN vegetation that needs to be done after hydrology-drainage
@@ -1100,6 +1100,7 @@ contains
     type(soilbiogeochem_carbonstate_type)   , intent(inout) :: c14_soilbiogeochem_carbonstate_inst
     type(soilbiogeochem_nitrogenflux_type)  , intent(inout) :: soilbiogeochem_nitrogenflux_inst
     type(soilbiogeochem_nitrogenstate_type) , intent(inout) :: soilbiogeochem_nitrogenstate_inst
+     type(cn_products_type)                 , intent(inout) :: c_products_inst    
     !
     ! !LOCAL VARIABLES:
 
@@ -1141,7 +1142,6 @@ contains
     call t_stopf('SoilBiogeochemPrecisionControl')
 
     ! Call to all CN summary routines
-
     call CNDriverSummarizeStates(bounds, &
          num_allc, filter_allc, &
          num_bgc_soilc, filter_bgc_soilc, &

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -1188,7 +1188,7 @@ contains
     end if
 
     if(use_fates_bgc)then
-      call clm_fates%wrap_AtmosphericCarbonFluxes(bounds,soilbiogeochem_carbonflux_inst,this%cnveg_carbonflux_inst,c_products_inst)
+      call clm_fates%wrap_AtmosphericCarbonFluxes(bounds,soilbiogeochem_carbonflux_inst,soilbiogeochem_carbonstate_inst)
     endif
 
     

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1123,7 +1123,8 @@ contains
                soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst, &
                c13_soilbiogeochem_carbonflux_inst, c13_soilbiogeochem_carbonstate_inst, &
                c14_soilbiogeochem_carbonflux_inst, c14_soilbiogeochem_carbonstate_inst, &
-               soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst, c_products_inst)
+               soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst, c_products_inst,&
+               clm_fates)
           call t_stopf('EcosysDynPostDrainage')
        end if
 
@@ -1152,7 +1153,7 @@ contains
                   water_inst%wateratm2lndbulk_inst, canopystate_inst, soilbiogeochem_carbonflux_inst, &
                   frictionvel_inst, soil_water_retention_curve)
              if(use_fates)then
-               call clm_fates%wrap_AtmosphericCarbonFluxes(nc,bounds_proc,soilbiogeochem_carbonflux_inst,c_products_inst)
+!               call clm_fates%wrap_AtmosphericCarbonFluxes(nc,bounds_proc,soilbiogeochem_carbonflux_inst,c_products_inst)
              endif
              ! TODO(wjs, 2016-04-01) I think this setFilters call should be replaced by a
              ! call to reweight_wrapup, if it's needed at all.

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -84,6 +84,7 @@ module clm_driver
   use clm_instMod
   use SoilMoistureStreamMod  , only : PrescribedSoilMoistureInterp, PrescribedSoilMoistureAdvance
   use SoilBiogeochemDecompCascadeConType , only : no_soil_decomp, decomp_method
+  use CNProductsMod                   , only : cn_products_type
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -128,6 +129,9 @@ contains
     logical,         intent(in) :: nlend       ! true => end of run on this step
     character(len=*),intent(in) :: rdate       ! restart file time stamp for name
 
+    !where are all the other instances defined? I can't figure this out! 
+    type(cn_products_type)   :: c_products_inst
+    
     ! Whether we're running with a prognostic ROF component. This shouldn't change from
     ! timestep to timestep, but we pass it into the driver loop because it isn't available
     ! in initialization.
@@ -1104,7 +1108,6 @@ contains
 
        call t_stopf('hydro2_drainage')
 
-       
        if (use_cn .or. use_fates_bgc) then
           call t_startf('EcosysDynPostDrainage')
           call bgc_vegetation_inst%EcosystemDynamicsPostDrainage(bounds_clump, &
@@ -1120,7 +1123,7 @@ contains
                soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst, &
                c13_soilbiogeochem_carbonflux_inst, c13_soilbiogeochem_carbonstate_inst, &
                c14_soilbiogeochem_carbonflux_inst, c14_soilbiogeochem_carbonstate_inst, &
-               soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst)
+               soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst, c_products_inst)
           call t_stopf('EcosysDynPostDrainage')
        end if
 
@@ -1148,7 +1151,9 @@ contains
                   water_inst%waterstatebulk_inst, water_inst%waterdiagnosticbulk_inst, &
                   water_inst%wateratm2lndbulk_inst, canopystate_inst, soilbiogeochem_carbonflux_inst, &
                   frictionvel_inst, soil_water_retention_curve)
-
+             if(use_fates)then
+               call clm_fates%wrap_AtmosphericCarbonFluxes(nc,bounds_proc,soilbiogeochem_carbonflux_inst,c_products_inst)
+             endif
              ! TODO(wjs, 2016-04-01) I think this setFilters call should be replaced by a
              ! call to reweight_wrapup, if it's needed at all.
              call setFilters( bounds_clump, glc_behavior )
@@ -1304,9 +1309,13 @@ contains
     ! based on similar pgi compiler bugs that we have run into before). Also note that I
     ! don't have explicit bounds on the left-hand-side of this assignment: excluding these
     ! explicit bounds seemed to be needed to get around other compiler bugs.
-    allocate(net_carbon_exchange_grc(bounds_proc%begg:bounds_proc%endg))
-    net_carbon_exchange_grc = bgc_vegetation_inst%get_net_carbon_exchange_grc(bounds_proc)
 
+    allocate(net_carbon_exchange_grc(bounds_proc%begg:bounds_proc%endg))
+    if(use_fates)then
+       net_carbon_exchange_grc = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds_proc%begg:bounds_proc%endg)
+    else
+       net_carbon_exchange_grc = bgc_vegetation_inst%get_net_carbon_exchange_grc(bounds_proc)
+    endif
     call lnd2atm(bounds_proc,                                            &
          atm2lnd_inst, surfalb_inst, temperature_inst, frictionvel_inst, &
          water_inst, &

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1045,6 +1045,7 @@ contains
           call t_stopf('ecosysdyn')
        end if
 
+       
        ! Prescribed biogeography - prescribed canopy structure, some prognostic carbon fluxes
 
        if (((.not. use_cn) .and. (.not. use_fates) .and. (doalb))) then
@@ -1312,7 +1313,7 @@ contains
     ! explicit bounds seemed to be needed to get around other compiler bugs.
 
     allocate(net_carbon_exchange_grc(bounds_proc%begg:bounds_proc%endg))
-    if(use_fates)then
+    if(use_fates_bgc)then
        net_carbon_exchange_grc = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds_proc%begg:bounds_proc%endg)
     else
        net_carbon_exchange_grc = bgc_vegetation_inst%get_net_carbon_exchange_grc(bounds_proc)

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -283,10 +283,6 @@ contains
              avgflag='A', long_name='FATES net ecosystem productivity', &
              ptr_col=this%fates_nee_col)
 
-        call hist_addfld1d (fname='FATES_NEP', units='gC/m^2/s', &
-             avgflag='A', long_name='FATES net ecosystem productivity', &
-             ptr_col=this%fates_nep_col)
-
         call hist_addfld1d (fname='FATES_NBP', units='gC/m^2/s', &
              avgflag='A', long_name='FATES net biome productivity', &
              ptr_col=this%fates_nbp_col)

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -52,7 +52,13 @@ module SoilBiogeochemCarbonFluxType
      ! nitrif_denitrif
      real(r8), pointer :: phr_vr_col                                (:,:)   ! (gC/m3/s) potential hr (not N-limited) 
      real(r8), pointer :: fphr_col                                  (:,:)   ! fraction of potential heterotrophic respiration
-
+     !-----FATES compposite fluxes ----------!
+     real(r8), pointer :: fates_nee_col                                   (:)     ! (gC/m2/s) net ecosystem exchange when FATES is on
+     real(r8), pointer :: fates_nep_col                                   (:)     ! (gC/m2/s) net ecosystem productivity when FATES is on
+     real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  
+     real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on
+     
+     ! ----- Hetertrophic Respiration fluxes --------!
      real(r8), pointer :: hr_col                                    (:)     ! (gC/m2/s) total heterotrophic respiration
      real(r8), pointer :: michr_col                                 (:)     ! (gC/m2/s) microbial heterotrophic respiration: donor-pool based definition, so expect it to be zero with MIMICS; microbial decomposition is responsible for heterotrophic respiration of donor pools (litter and soil), but in the accounting we assign it to the donor pool for consistency with CENTURY
      real(r8), pointer :: cwdhr_col                                 (:)     ! (gC/m2/s) coarse woody debris heterotrophic respiration: donor-pool based definition
@@ -121,12 +127,14 @@ contains
      ! !LOCAL VARIABLES:
      integer           :: begp,endp            ! Begin and end patch
      integer           :: begc,endc            ! Begin and end column
+      integer           :: begg,endg
      integer           :: Ntrans,Ntrans_diag   ! N trans size for matrix solution
      !------------------------------------------------------------------------
 
      begp = bounds%begp; endp = bounds%endp
      begc = bounds%begc; endc = bounds%endc
-
+     begg = bounds%begg; endg = bounds%endg
+     
      allocate(this%t_scalar_col      (begc:endc,1:nlevdecomp_full)); this%t_scalar_col      (:,:) =spval
      allocate(this%w_scalar_col      (begc:endc,1:nlevdecomp_full)); this%w_scalar_col      (:,:) =spval
      allocate(this%o_scalar_col      (begc:endc,1:nlevdecomp_full)); this%o_scalar_col      (:,:) =spval
@@ -171,6 +179,12 @@ contains
 
      allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))          
      this%decomp_cpools_transport_tendency_col(:,:,:)= nan
+      if(use_fates)then
+        allocate(this%fates_nee_col                (begc:endc)) ; this%fates_nee_col          (:) = nan
+        allocate(this%fates_nep_col                (begc:endc)) ; this%fates_nep_col          (:) = nan
+        allocate(this%fates_nbp_col                (begc:endc)) ; this%fates_nbp_col          (:) = nan
+        allocate(this%fates_nbp_grc                (begg:endg)) ; this%fates_nbp_grc          (:) = nan
+       endif
 
      allocate(this%hr_col                  (begc:endc)) ; this%hr_col                  (:) = nan
      allocate(this%michr_col               (begc:endc)) ; this%michr_col               (:) = nan
@@ -235,6 +249,7 @@ contains
      character(10)     :: active
      integer           :: begp,endp
      integer           :: begc,endc
+     integer           :: begg,endg
      character(24)     :: fieldname
      character(100)    :: longname
      real(r8), pointer :: data1dptr(:)   ! temp. pointer for slicing larger arrays
@@ -243,7 +258,8 @@ contains
 
      begp = bounds%begp; endp = bounds%endp
      begc = bounds%begc; endc = bounds%endc
-
+     begg = bounds%begg; endg = bounds%endg
+     
      if (nlevdecomp > 1) then
         vr_suffix = "_vr"
      else 
@@ -255,7 +271,20 @@ contains
      !-------------------------------
 
      ! add history fields for all CLAMP CN variables
+     if (use_fates)then
+        call hist_addfld1d (fname='FATES_NEE', units='gC/m^2/s', &
+             avgflag='A', long_name='FATES net ecosystem productivity', &
+             ptr_col=this%fates_nee_col)
 
+        call hist_addfld1d (fname='FATES_NEP', units='gC/m^2/s', &
+             avgflag='A', long_name='FATES net ecosystem productivity', &
+             ptr_col=this%fates_nep_col)
+
+        call hist_addfld1d (fname='FATES_NBP', units='gC/m^2/s', &
+             avgflag='A', long_name='FATES net biome productivity', &
+             ptr_col=this%fates_nbp_col)
+
+     endif    
      if (carbon_type == 'c12') then
 
         this%hr_col(begc:endc) = spval
@@ -306,7 +335,15 @@ contains
                 avgflag='A', long_name=longname, &
                 ptr_col=data2dptr, default='inactive')
         end do
+        
+        if(use_fates)then
+           this%fates_nee_col(begc:endc)             = spval
+           this%fates_nep_col(begc:endc)             = spval
+           this%fates_nbp_col(begc:endc)             = spval
+           this%fates_nbp_grc(begg:endg)             = spval
+         endif 
 
+           
         this%decomp_cascade_hr_col(begc:endc,:)             = spval
         this%decomp_cascade_hr_vr_col(begc:endc,:,:)        = spval
         this%decomp_cascade_ctransfer_col(begc:endc,:)      = spval
@@ -787,6 +824,11 @@ contains
 
     do fi = 1,num_column
        i = filter_column(fi)
+       if(use_fates)then
+          this%fates_nee_col(i)           = value_column
+          this%fates_nep_col(i)           = value_column
+          this%fates_nbp_col(i)           = value_column       
+       endif
        this%hr_col(i)            = value_column
        this%somc_fire_col(i)     = value_column  
        this%som_c_leached_col(i) = value_column
@@ -955,7 +997,7 @@ contains
             this%cwdhr_col(c) + &
             this%lithr_col(c) + &
             this%somhr_col(c)
-       
+
     end do
 
     ! Calculate ligninNratio

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -58,7 +58,6 @@ module SoilBiogeochemCarbonFluxType
      real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  
      real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on
      real(r8), pointer :: fates_product_loss_grc                          (:)     ! (gC/m2/s) total loss from product pools for calcualtion of fates_nbp
-     real(r8), pointer :: fates_total_carbon_col                          (:)     ! (gC/m2) total carbon in all FATES variables for HLM NBP balance check
      
      ! ----- Hetertrophic Respiration fluxes --------!
      real(r8), pointer :: hr_col                                    (:)     ! (gC/m2/s) total heterotrophic respiration
@@ -187,7 +186,6 @@ contains
         allocate(this%fates_nbp_col                (begc:endc)) ; this%fates_nbp_col          (:) = nan
         allocate(this%fates_nbp_grc                (begg:endg)) ; this%fates_nbp_grc          (:) = nan
         allocate(this%fates_product_loss_grc       (begg:endg)) ; this%fates_product_loss_grc (:) = nan
-        allocate(this%fates_total_carbon_col       (begg:endg)) ; this%fates_total_carbon_col (:) = nan
      endif
 
      allocate(this%hr_col                  (begc:endc)) ; this%hr_col                  (:) = nan
@@ -288,10 +286,6 @@ contains
              avgflag='A', long_name='FATES net biome productivity', &
              ptr_col=this%fates_nbp_col)
 
-        call hist_addfld1d (fname='FATES_TOTAL_CARBON', units='gC/m^2', &
-             avgflag='A', long_name='FATES total carbon stock (biomass + litter + seeds)', &
-             ptr_col=this%fates_total_carbon_col)
-        
      endif    
      if (carbon_type == 'c12') then
 
@@ -350,7 +344,6 @@ contains
            this%fates_nbp_col(begc:endc)             = spval
            this%fates_nbp_grc(begg:endg)             = spval
            this%fates_product_loss_grc(begg:endg)    = spval
-           this%fates_total_carbon_col(begc:endc)    = spval
          endif 
 
            
@@ -838,7 +831,6 @@ contains
           this%fates_nee_col(i)           = value_column
           this%fates_nep_col(i)           = value_column
           this%fates_nbp_col(i)           = value_column
-          this%fates_total_carbon_col(i)  = value_column
        endif
        this%hr_col(i)            = value_column
        this%somc_fire_col(i)     = value_column  

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -6,7 +6,7 @@ module SoilBiogeochemCarbonFluxType
   use clm_varpar                         , only : ndecomp_cascade_transitions, ndecomp_pools, ndecomp_cascade_outtransitions
   use clm_varpar                         , only : nlevdecomp_full, nlevgrnd, nlevdecomp, nlevsoi, ndecomp_pools_vr, i_cwdl2
   use clm_varcon                         , only : spval, ispval, dzsoi_decomp
-  use clm_varctl                         , only : use_fates,use_cn
+  use clm_varctl                         , only : use_fates,use_fates_bgc,use_cn
   use pftconMod                          , only : pftcon
   use landunit_varcon                    , only : istsoil, istcrop, istdlak 
   use ch4varcon                          , only : allowlakeprod
@@ -58,6 +58,7 @@ module SoilBiogeochemCarbonFluxType
      real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  
      real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on
      real(r8), pointer :: fates_product_loss_grc                          (:)     ! (gC/m2/s) total loss from product pools for calcualtion of fates_nbp
+     real(r8), pointer :: fates_total_carbon_col                          (:)     ! (gC/m2) total carbon in all FATES variables for HLM NBP balance check
      
      ! ----- Hetertrophic Respiration fluxes --------!
      real(r8), pointer :: hr_col                                    (:)     ! (gC/m2/s) total heterotrophic respiration
@@ -180,12 +181,13 @@ contains
 
      allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))          
      this%decomp_cpools_transport_tendency_col(:,:,:)= nan
-      if(use_fates)then
+      if(use_fates_bgc)then
         allocate(this%fates_nee_col                (begc:endc)) ; this%fates_nee_col          (:) = nan
         allocate(this%fates_nep_col                (begc:endc)) ; this%fates_nep_col          (:) = nan
         allocate(this%fates_nbp_col                (begc:endc)) ; this%fates_nbp_col          (:) = nan
         allocate(this%fates_nbp_grc                (begg:endg)) ; this%fates_nbp_grc          (:) = nan
         allocate(this%fates_product_loss_grc       (begg:endg)) ; this%fates_product_loss_grc (:) = nan
+        allocate(this%fates_total_carbon_col       (begg:endg)) ; this%fates_total_carbon_col (:) = nan
      endif
 
      allocate(this%hr_col                  (begc:endc)) ; this%hr_col                  (:) = nan
@@ -273,7 +275,7 @@ contains
      !-------------------------------
 
      ! add history fields for all CLAMP CN variables
-     if (use_fates)then
+     if (use_fates_bgc)then
         call hist_addfld1d (fname='FATES_NEE', units='gC/m^2/s', &
              avgflag='A', long_name='FATES net ecosystem productivity', &
              ptr_col=this%fates_nee_col)
@@ -285,6 +287,10 @@ contains
         call hist_addfld1d (fname='FATES_NBP', units='gC/m^2/s', &
              avgflag='A', long_name='FATES net biome productivity', &
              ptr_col=this%fates_nbp_col)
+
+        call hist_addfld1d (fname='FATES_TOTAL_CARBON', units='gC/m^2', &
+             avgflag='A', long_name='FATES total carbon stock (biomass + litter + seeds)', &
+             ptr_col=this%fates_total_carbon_col)
         
      endif    
      if (carbon_type == 'c12') then
@@ -338,12 +344,13 @@ contains
                 ptr_col=data2dptr, default='inactive')
         end do
         
-        if(use_fates)then
+        if(use_fates_bgc)then
            this%fates_nee_col(begc:endc)             = spval
            this%fates_nep_col(begc:endc)             = spval
            this%fates_nbp_col(begc:endc)             = spval
            this%fates_nbp_grc(begg:endg)             = spval
            this%fates_product_loss_grc(begg:endg)    = spval
+           this%fates_total_carbon_col(begc:endc)    = spval
          endif 
 
            
@@ -827,10 +834,11 @@ contains
 
     do fi = 1,num_column
        i = filter_column(fi)
-       if(use_fates)then
+       if(use_fates_bgc)then
           this%fates_nee_col(i)           = value_column
           this%fates_nep_col(i)           = value_column
           this%fates_nbp_col(i)           = value_column
+          this%fates_total_carbon_col(i)  = value_column
        endif
        this%hr_col(i)            = value_column
        this%somc_fire_col(i)     = value_column  

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -285,8 +285,9 @@ contains
 
         call hist_addfld1d (fname='FATES_NBP', units='gC/m^2/s', &
              avgflag='A', long_name='FATES net biome productivity', &
-             ptr_col=this%fates_nbp_col)
-
+             ptr_gcell=this%fates_nbp_grc)
+        ! this is writing the COLUMN level NBP, but we want to write out the gridcell fluxes. 
+        
         call hist_addfld1d (fname='FATES_FIRE_GRAZING', units='gC/m^2/s', &
              avgflag='A', long_name='FATES fire and grazing fluxes (NBP-NEP) ', &
              ptr_col=this%fates_fire_grazing_col)
@@ -864,7 +865,7 @@ contains
     ! On the radiation time step, carbon summary calculations
     !
     ! !USES:
-    use subgridAveMod, only: p2c
+    use subgridAveMod, only: p2c , c2g
     use CNSharedParamsMod, only: CNParamsShareInst
 
     ! !ARGUMENTS:
@@ -883,7 +884,7 @@ contains
     real(r8), intent(in), optional :: frootc_to_litter_patch(:)
     !
     ! !LOCAL VARIABLES:
-    integer  :: c,j,k,l,p
+    integer  :: c,j,k,l,p,g
     integer  :: fc, fp
     real(r8) :: ligninNratio_cwd  ! lignin to N ratio of CWD
     real(r8) :: ligninNratio_leaf_patch(bounds%begp:bounds%endp)  ! lignin to N ratio of leaves, patch level
@@ -1077,12 +1078,25 @@ contains
        if(col%is_fates(c)) then
          ! These are all gc/,2/s and instantaneous.                                                       
          this%fates_nep_col(c) = this%fates_npp_col(c) - this%hr_col(c)
-         this%fates_nbp_col(c) = this%fates_nep_col(c) - this%fates_fire_grazing_col(c) !- product_loss(c)
-         ! need to take off product pools
+         this%fates_nbp_col(c) = this%fates_nep_col(c) - this%fates_fire_grazing_col(c)
+         ! do not add product loss here as it is a gridcell variable
+
        end if
     end do
 
+    ! create the gridcell level NBP variable
+    call c2g( bounds = bounds, &
+            carr = this%fates_nbp_col(bounds%begc:bounds%endc), &
+            garr = this%fates_nbp_grc(bounds%begg:bounds%endg), &
+            c2l_scale_type = 'unity', &
+            l2g_scale_type = 'unity')
 
+    ! remove the gridcell level product_loss flux are the gridcell level.
+    ! this is a FATES variable that is passed into this module after the product pool summary. 
+    do g = bounds%begg,bounds%endg
+       this%fates_nbp_grc(g) = this%fates_nbp_grc(g) - this%fates_product_loss_grc(g) 
+    enddo 
+       
   end subroutine Summary
 
 end module SoilBiogeochemCarbonFluxType

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -57,6 +57,7 @@ module SoilBiogeochemCarbonFluxType
      real(r8), pointer :: fates_nep_col                                   (:)     ! (gC/m2/s) net ecosystem productivity when FATES is on
      real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  
      real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on
+     real(r8), pointer :: fates_product_loss_grc                          (:)     ! (gC/m2/s) total loss from product pools for calcualtion of fates_nbp
      
      ! ----- Hetertrophic Respiration fluxes --------!
      real(r8), pointer :: hr_col                                    (:)     ! (gC/m2/s) total heterotrophic respiration
@@ -184,7 +185,8 @@ contains
         allocate(this%fates_nep_col                (begc:endc)) ; this%fates_nep_col          (:) = nan
         allocate(this%fates_nbp_col                (begc:endc)) ; this%fates_nbp_col          (:) = nan
         allocate(this%fates_nbp_grc                (begg:endg)) ; this%fates_nbp_grc          (:) = nan
-       endif
+        allocate(this%fates_product_loss_grc       (begg:endg)) ; this%fates_product_loss_grc (:) = nan
+     endif
 
      allocate(this%hr_col                  (begc:endc)) ; this%hr_col                  (:) = nan
      allocate(this%michr_col               (begc:endc)) ; this%michr_col               (:) = nan
@@ -283,7 +285,7 @@ contains
         call hist_addfld1d (fname='FATES_NBP', units='gC/m^2/s', &
              avgflag='A', long_name='FATES net biome productivity', &
              ptr_col=this%fates_nbp_col)
-
+        
      endif    
      if (carbon_type == 'c12') then
 
@@ -341,6 +343,7 @@ contains
            this%fates_nep_col(begc:endc)             = spval
            this%fates_nbp_col(begc:endc)             = spval
            this%fates_nbp_grc(begg:endg)             = spval
+           this%fates_product_loss_grc(begg:endg)    = spval
          endif 
 
            
@@ -827,7 +830,7 @@ contains
        if(use_fates)then
           this%fates_nee_col(i)           = value_column
           this%fates_nep_col(i)           = value_column
-          this%fates_nbp_col(i)           = value_column       
+          this%fates_nbp_col(i)           = value_column
        endif
        this%hr_col(i)            = value_column
        this%somc_fire_col(i)     = value_column  
@@ -838,7 +841,7 @@ contains
        this%michr_col(i)         = value_column
        this%soilc_change_col(i)  = value_column
     end do
-
+    
   end subroutine SetValues
 
   !-----------------------------------------------------------------------

--- a/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonFluxType.F90
@@ -53,10 +53,13 @@ module SoilBiogeochemCarbonFluxType
      real(r8), pointer :: phr_vr_col                                (:,:)   ! (gC/m3/s) potential hr (not N-limited) 
      real(r8), pointer :: fphr_col                                  (:,:)   ! fraction of potential heterotrophic respiration
      !-----FATES compposite fluxes ----------!
+     real(r8), pointer :: fates_npp_col                                   (:)     ! (gC/m2/s) net ecosystem exchange when FATES is on
      real(r8), pointer :: fates_nee_col                                   (:)     ! (gC/m2/s) net ecosystem exchange when FATES is on
      real(r8), pointer :: fates_nep_col                                   (:)     ! (gC/m2/s) net ecosystem productivity when FATES is on
-     real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  
-     real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on
+
+     real(r8), pointer :: fates_nbp_col                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  column level
+     real(r8), pointer :: fates_nbp_grc                                   (:)     ! (gC/m2/s) net biome productivity when FATES is on  gridcell level
+     real(r8), pointer :: fates_fire_grazing_col                                       (:)     ! (gC/m2/s) fire plus grazing fluxes to the atmosphere (happen the -next- day as fire & grazing are calcualted at midnight. 
      real(r8), pointer :: fates_product_loss_grc                          (:)     ! (gC/m2/s) total loss from product pools for calcualtion of fates_nbp
      
      ! ----- Hetertrophic Respiration fluxes --------!
@@ -181,10 +184,12 @@ contains
      allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))          
      this%decomp_cpools_transport_tendency_col(:,:,:)= nan
       if(use_fates_bgc)then
+        allocate(this%fates_npp_col                (begc:endc)) ; this%fates_npp_col          (:) = nan
         allocate(this%fates_nee_col                (begc:endc)) ; this%fates_nee_col          (:) = nan
         allocate(this%fates_nep_col                (begc:endc)) ; this%fates_nep_col          (:) = nan
         allocate(this%fates_nbp_col                (begc:endc)) ; this%fates_nbp_col          (:) = nan
         allocate(this%fates_nbp_grc                (begg:endg)) ; this%fates_nbp_grc          (:) = nan
+        allocate(this%fates_fire_grazing_col       (begc:endc)) ; this%fates_fire_grazing_col (:) = nan
         allocate(this%fates_product_loss_grc       (begg:endg)) ; this%fates_product_loss_grc (:) = nan
      endif
 
@@ -286,6 +291,9 @@ contains
              avgflag='A', long_name='FATES net biome productivity', &
              ptr_col=this%fates_nbp_col)
 
+        call hist_addfld1d (fname='FATES_FIRE_GRAZING', units='gC/m^2/s', &
+             avgflag='A', long_name='FATES fire and grazing fluxes (NBP-NEP) ', &
+             ptr_col=this%fates_fire_grazing_col)
      endif    
      if (carbon_type == 'c12') then
 
@@ -339,9 +347,11 @@ contains
         end do
         
         if(use_fates_bgc)then
+	   this%fates_npp_col(begc:endc)             = spval
            this%fates_nee_col(begc:endc)             = spval
            this%fates_nep_col(begc:endc)             = spval
            this%fates_nbp_col(begc:endc)             = spval
+           this%fates_fire_grazing_col(begc:endc)    = spval
            this%fates_nbp_grc(begg:endg)             = spval
            this%fates_product_loss_grc(begg:endg)    = spval
          endif 
@@ -828,9 +838,11 @@ contains
     do fi = 1,num_column
        i = filter_column(fi)
        if(use_fates_bgc)then
+          this%fates_npp_col(i)           = value_column
           this%fates_nee_col(i)           = value_column
           this%fates_nep_col(i)           = value_column
           this%fates_nbp_col(i)           = value_column
+          this%fates_fire_grazing_col(i)           = value_column
        endif
        this%hr_col(i)            = value_column
        this%somc_fire_col(i)     = value_column  
@@ -840,6 +852,7 @@ contains
        this%cwdhr_col(i)         = value_column
        this%michr_col(i)         = value_column
        this%soilc_change_col(i)  = value_column
+
     end do
     
   end subroutine SetValues
@@ -869,6 +882,7 @@ contains
     real(r8), intent(in), optional :: soilbiogeochem_cwdn_col(bounds%begc:)
     real(r8), intent(in), optional :: soilbiogeochem_decomp_cascade_ctransfer_col(bounds%begc:,1:)
 
+    
     real(r8), intent(in), optional :: leafc_to_litter_patch(:)
     real(r8), intent(in), optional :: frootc_to_litter_patch(:)
     !
@@ -1000,7 +1014,7 @@ contains
             this%cwdhr_col(c) + &
             this%lithr_col(c) + &
             this%somhr_col(c)
-
+       
     end do
 
     ! Calculate ligninNratio
@@ -1052,13 +1066,26 @@ contains
                   max(1.0e-3_r8, leafc_to_litter_col(c) + &
                   frootc_to_litter_col(c) + &
                   soilbiogeochem_decomp_cascade_ctransfer_col(c,i_cwdl2))
-          !else
-             ! For FATES:
-             ! this array is currently updated here:
-             ! clmfates_interfaceMod.F90:wrap_update_hlmfates_dyn()
+           else
+             ! fates does not work with MIMICS yet! 
           end if
        end do
     end if if_mimics
+
+
+    do fc = 1,num_bgc_soilc
+       c = filter_bgc_soilc(fc)
+
+       ! For FATES, we update the coposite flux pools here with the infomationwe                            
+       ! recevied from FATES on column level NPP and grazing/fire fluxes.
+       if(col%is_fates(c)) then
+         ! These are all gc/,2/s and instantaneous.                                                       
+         this%fates_nep_col(c) = this%fates_npp_col(c) - this%hr_col(c)
+         this%fates_nbp_col(c) = this%fates_nep_col(c) - this%fates_fire_grazing_col(c) !- product_loss(c)
+         ! need to take off product pools
+       end if
+    end do
+
 
   end subroutine Summary
 

--- a/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
@@ -53,8 +53,8 @@ module SoilBiogeochemCarbonStateType
      real(r8), pointer :: totc_col                            (:) ! (gC/m2) total column carbon, incl veg and cpool
      real(r8), pointer :: totecosysc_col                      (:) ! (gC/m2) total ecosystem carbon, incl veg but excl cpool 
      real(r8), pointer :: totc_grc                            (:) ! (gC/m2) total gridcell carbon
-
-     
+     real(r8), pointer :: fates_total_carbon_col              (:) ! (gC/m2) total carbon contain in FATES state variables (vegetation, seeds, litter) for gridcell balance check. 
+      
      ! Matrix-cn
      real(r8), pointer :: matrix_cap_decomp_cpools_col    (:,:)   ! (gC/m2) C capacity in decomposing (litter, cwd, soil) N pools in dimension (col,npools)
      real(r8), pointer :: matrix_cap_decomp_cpools_vr_col (:,:,:) ! (gC/m3) vertically-resolved C capacity in decomposing (litter, cwd, soil) pools in dimension(col,nlev,npools)
@@ -177,7 +177,10 @@ contains
     allocate(this%totc_col                 (begc:endc)) ; this%totc_col                 (:) = nan
     allocate(this%totecosysc_col           (begc:endc)) ; this%totecosysc_col           (:) = nan
     allocate(this%totc_grc                 (begg:endg)) ; this%totc_grc                 (:) = nan
-    
+    if(use_fates_bgc)then
+      allocate(this%fates_total_carbon_col   (begg:endg)) ; this%fates_total_carbon_col   (:) = nan
+    endif
+
     this%restart_file_spinup_state = huge(1)
 
   end subroutine InitAllocate
@@ -288,6 +291,12 @@ contains
             avgflag='A', long_name='total soil organic matter carbon', &
             ptr_col=this%totsomc_col)
 
+       if(use_fates_bgc)then
+          call hist_addfld1d (fname='FATES_TOTAL_CARBON', units='gC/m^2', &
+               avgflag='A', long_name='FATES total carbon stock (biomass + litter + seeds)', &
+               ptr_col=this%fates_total_carbon_col)
+       endif
+       
        if ( nlevdecomp_full > 1 ) then
           this%totlitc_1m_col(begc:endc) = spval
           call hist_addfld1d (fname='TOTLITC_1m', units='gC/m^2', &
@@ -1616,8 +1625,8 @@ contains
           c = filter_allc(fc)
        end if
        if(col%is_fates(c)) then
-          totvegc_col = 0._r8
-          ecovegc_col = 0._r8
+          totvegc_col = this%fates_total_carbon_col(c) 
+          ecovegc_col = this%fates_total_carbon_col(c)
        else
           do l = 1, ndecomp_pools
              if ( decomp_cascade_con%is_cwd(l) ) then

--- a/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
@@ -695,6 +695,10 @@ contains
           this%totc_col(c)       = 0._r8
           this%totecosysc_col(c) = 0._r8
        end if
+
+       if(if (col%is_fates(c) ) )then
+         fates_total_carbon_col(c) = 0._r8
+       endif 
        
     end do
 
@@ -1636,7 +1640,7 @@ contains
           totvegc_col = cnveg_carbonstate_inst%totc_p2c_col(c)
           ecovegc_col = cnveg_carbonstate_inst%totvegc_col(c)
        end if
-       
+       write(*,*) 'ecoveg,totveg',ecovegc_col,totvegc_col
        ! total ecosystem carbon, including veg but excluding cpool (TOTECOSYSC)
        this%totecosysc_col(c) =   &
             this%cwdc_col(c)    + &

--- a/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCarbonStateType.F90
@@ -1,5 +1,5 @@
 module SoilBiogeochemCarbonStateType
-
+  
   use shr_kind_mod                       , only : r8 => shr_kind_r8
   use shr_infnan_mod                     , only : nan => shr_infnan_nan, assignment(=)
   use shr_log_mod                        , only : errMsg => shr_log_errMsg
@@ -178,7 +178,7 @@ contains
     allocate(this%totecosysc_col           (begc:endc)) ; this%totecosysc_col           (:) = nan
     allocate(this%totc_grc                 (begg:endg)) ; this%totc_grc                 (:) = nan
     if(use_fates_bgc)then
-      allocate(this%fates_total_carbon_col   (begg:endg)) ; this%fates_total_carbon_col   (:) = nan
+      allocate(this%fates_total_carbon_col   (begc:endc)) ; this%fates_total_carbon_col   (:) = nan
     endif
 
     this%restart_file_spinup_state = huge(1)
@@ -696,8 +696,8 @@ contains
           this%totecosysc_col(c) = 0._r8
        end if
 
-       if(if (col%is_fates(c) ) )then
-         fates_total_carbon_col(c) = 0._r8
+       if(use_fates_bgc)then
+          this%fates_total_carbon_col(c) = 0._r8
        endif 
        
     end do
@@ -1343,6 +1343,8 @@ contains
        i = filter_column(fi)
        if ( .not. col%is_fates(i) ) then
           this%cwdc_col(i)       = value_column
+       else
+          this%fates_total_carbon_col(i) = value_column
        end if
        this%ctrunc_col(i)     = value_column
        this%totmicc_col(i)    = value_column
@@ -1622,6 +1624,7 @@ contains
     else
        num_local = num_allc
     end if
+    
     do fc = 1,num_local
        if(use_fates_bgc) then
           c = filter_bgc_soilc(fc)
@@ -1632,6 +1635,10 @@ contains
           totvegc_col = this%fates_total_carbon_col(c) 
           ecovegc_col = this%fates_total_carbon_col(c)
        else
+          if(use_fates_bgc)then
+             totvegc_col = 0._r8
+             ecovegc_col = 0._r8
+          endif
           do l = 1, ndecomp_pools
              if ( decomp_cascade_con%is_cwd(l) ) then
                 this%cwdc_col(c) = this%cwdc_col(c) + this%decomp_cpools_col(c,l)
@@ -1640,7 +1647,6 @@ contains
           totvegc_col = cnveg_carbonstate_inst%totc_p2c_col(c)
           ecovegc_col = cnveg_carbonstate_inst%totvegc_col(c)
        end if
-       write(*,*) 'ecoveg,totveg',ecovegc_col,totvegc_col
        ! total ecosystem carbon, including veg but excluding cpool (TOTECOSYSC)
        this%totecosysc_col(c) =   &
             this%cwdc_col(c)    + &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1,3 +1,4 @@
+
 module CLMFatesInterfaceMod
 
    ! -------------------------------------------------------------------------------------
@@ -2940,7 +2941,7 @@ module CLMFatesInterfaceMod
    ! NEP, NEE and NBP are outputs
    ! product loss, hr and fire are inputs. 
    associate(&
-        nep     => cnveg_carbonflux_inst%nep_col    , &
+        nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
         nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
         product_closs => c_products_inst%product_loss_grc ,  &   ! Gridcell level product C loss from all pools. gC/m2/s
         hr     => soilbiogeochem_carbonflux_inst%hr_col) 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2957,12 +2957,17 @@ module CLMFatesInterfaceMod
        nep(c) = this%fates(nc)%bc_out(s)%npp_site - hr(c) 
        ! hr should already by in g/m2/s 
 
+       ! g/m2/s 
        nbp(c) = nep(c) &
             - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
             - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
-           - product_closs(g)
-
+            - product_closs(g)
+       
+       ! Pass the carbon pools in FATES to be included inthe gridcell balance check. g/m2/s 
        fates_total_carbon(c) = this%fates(nc)%bc_out(s)%fates_total_carbon_site
+       ! Add the instantaneous amount of carbon in the accumulated NPP pool (which at this model timestep has not bee allocated to a FATES biomass pool but will be at the end of the day)
+       fates_total_carbon(c) =  fates_total_carbon(c) + this%fates(nc)%bc_out(s)%npp_acc_site
+       
        write(*,*) 'in fates utils',c,nep(c),nbp(c),fates_total_carbon(c) 
     end do
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2922,7 +2922,7 @@ module CLMFatesInterfaceMod
  
 ! ======================================================================================
 
- subroutine wrap_atmosphericCarbonFluxes(this,bounds_clump,soilbiogeochem_carbonflux_inst,cnveg_carbonflux_inst)
+ subroutine wrap_atmosphericCarbonFluxes(this,bounds_clump,soilbiogeochem_carbonflux_inst,soilbiogeochem_carbonstate_inst)
 
    ! summarize the high-level fluxes that integrate information from both
    ! FATES and outside-of-FATES decomposition and product decay code.
@@ -2934,16 +2934,18 @@ module CLMFatesInterfaceMod
    class(hlm_fates_interface_type), intent(inout) :: this
    integer  :: nc   
    type(soilbiogeochem_carbonflux_type), intent(in)    :: soilbiogeochem_carbonflux_inst
-   type(cnveg_carbonflux_type)         , intent(inout) :: cnveg_carbonflux_inst
+   type(soilbiogeochem_carbonstate_type)         , intent(inout) :: soilbiogeochem_carbonstate_inst
    integer          :: g,s,c
-
+   real             :: fates_total_carbon
+   
    ! NEP, NEE and NBP are outputs
    ! product loss, hr and fire are inputs. 
    associate(&
         nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
         nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
         product_closs => soilbiogeochem_carbonflux_inst%fates_product_loss_grc ,  &
-        hr     => soilbiogeochem_carbonflux_inst%hr_col) 
+        hr     => soilbiogeochem_carbonflux_inst%hr_col, &
+        fates_total_carbon => soilbiogeochem_carbonstate_inst%fates_total_carbon_col) 
 
     nc = bounds_clump%clump_index
 
@@ -2960,6 +2962,8 @@ module CLMFatesInterfaceMod
             - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
            - product_closs(g)
 
+       fates_total_carbon(c) = this%fates(nc)%bc_out(s)%fates_total_carbon_site
+       write(*,*) 'in fates utils',c,nep(c),nbp(c),fates_total_carbon(c) 
     end do
 
     call c2g( bounds = bounds_clump, &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2920,44 +2920,44 @@ module CLMFatesInterfaceMod
  
 ! ======================================================================================
 
- subroutine wrap_FatesAtmosphericCarbonFluxes(this, bounds_clump, fc, filterc)
+ subroutine wrap_FatesAtmosphericCarbonFluxes(this, bounds_clump, fc, filterc,cnveg_carbonflux_inst)
 
    ! summarize the high-level fluxes that integrate information from both
    ! FATES and outside-of-FATES decomposition and product decay code.
    
    use FatesConstantsMod     , only : g_per_kg
-   use cnveg_carbonfluxMod   , only : cnveg_carbonflux_inst
-   ! !ARGUMENTS:
+   use CNVegCarbonFluxType                , only : cnveg_carbonflux_type
+
+    ! !ARGUMENTS:
    class(hlm_fates_interface_type), intent(inout) :: this
    type(bounds_type)              , intent(in)    :: bounds_clump
    integer                        , intent(in)    :: fc                   ! size of column filter
    integer                        , intent(in)    :: filterc(fc)          ! column filter
+   type(cnveg_carbonflux_type) , intent(inout) ::   cnveg_carbonflux_inst
    
    ! Locacs
-   integer                                        :: s,c,icc
+   integer                                        :: g,s,c,icc
    integer                                        :: nc
 
    associate(&
-        nep     => col_cf%nep    , &
-        nee     => col_cf%nee    , &
-        nbp     => cnveg_carbonflux_inst%nbp_grc col_cf%nbp    , &
-        product_closs => col_cf%product_closs ,  &
-        hr     => col_cf%hr)
- 
-    nc = bounds_clump%clump_index
-    ! Loop over columns
-    do icc = 1,fc
-       c = filterc(icc)
-       s = this%f2hmap(nc)%hsites(c)
+        nep     => cnveg_carbonflux_inst%nep_col    , &
+        nee     => cnveg_carbonflux_inst%nee_grc    , &
+        nbp     => cnveg_carbonflux_inst%nbp_grc    )
+        !product_closs => cnveg_carbonflux_inst%product_closs ,  &
+        !hr     => cnveg_carbonflux_inst%hr)
+
+    do s = 1, this%fates(nc)%nsites
+       c = this%f2hmap(nc)%fcolumn(s)
+       g = col%gridcell(c)    
 
        nep(c) = this%fates(nc)%bc_out(s)%gpp_site*g_per_kg &
-            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg &
-            - hr(c)
+            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg !&
+  !          - hr(c)
 
-       nbp(c) = nep(c) &
-            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
-            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
-            - product_closs(c)
+       !nbp(c) = nep(c) &
+!            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
+!            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
+!            - product_closs(c)
 
        nee(c) = -nbp(c)
 
@@ -3685,7 +3685,7 @@ module CLMFatesInterfaceMod
     integer :: n
     integer :: num_filter_fates
     integer :: nlevsoil
-
+    integer :: nc
 
     if( .not. use_fates_planthydro ) return
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2936,15 +2936,17 @@ module CLMFatesInterfaceMod
    type(soilbiogeochem_carbonflux_type), intent(in)    :: soilbiogeochem_carbonflux_inst
    type(soilbiogeochem_carbonstate_type)         , intent(inout) :: soilbiogeochem_carbonstate_inst
    integer          :: g,s,c
-   real             :: fates_total_carbon
    
-   ! NEP, NEE and NBP are outputs
-   ! product loss, hr and fire are inputs. 
+   ! NPP,  grazing and fire and total carbon are the outputs from FATES that we pass to the HLM here
+   ! The composite fluxes are calculated using the HR and Product pools flues from the HLM in the
+   ! summary routines (which happen later).
+   ! Total carbon is needed for gridcell balance check purposes. 
+   ! All  fluxes here are in
+   
    associate(&
-        nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
-        nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
+        fates_npp     => soilbiogeochem_carbonflux_inst%fates_npp_col    , &
+        fire_grazing     => soilbiogeochem_carbonflux_inst%fates_fire_grazing_col    , &    
         product_closs => soilbiogeochem_carbonflux_inst%fates_product_loss_grc ,  &
-        hr     => soilbiogeochem_carbonflux_inst%hr_col, &
         fates_total_carbon => soilbiogeochem_carbonstate_inst%fates_total_carbon_col) 
 
     nc = bounds_clump%clump_index
@@ -2954,21 +2956,21 @@ module CLMFatesInterfaceMod
        g = col%gridcell(c)    
 
        ! Instantaneous site level NPP is calculate in FATES in AccumulateFluxes_ED
-       nep(c) = this%fates(nc)%bc_out(s)%npp_site - hr(c) 
-       ! hr should already by in g/m2/s 
+       ! NEP, NBP are calculated in the summary after hr_col is determineds.
+       fates_npp(c) = this%fates(nc)%bc_out(s)%npp_site
 
-       ! g/m2/s 
-       nbp(c) = nep(c) &
-            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
-            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
-            - product_closs(g)
-       
-       ! Pass the carbon pools in FATES to be included inthe gridcell balance check. g/m2/s 
-       fates_total_carbon(c) = this%fates(nc)%bc_out(s)%fates_total_carbon_site
-       ! Add the instantaneous amount of carbon in the accumulated NPP pool (which at this model timestep has not bee allocated to a FATES biomass pool but will be at the end of the day)
+       ! Convert yesteday's dribbled fluxes from fire and grazing from kgC/m2/s to g/m2/s 
+       fire_grazing(c) = this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
+            + this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg 
+
+       ! Total carbon in all FATES-side pools (biomass, litter & seeds). 
+       fates_total_carbon(c) = this%fates(nc)%bc_out(s)%fates_total_carbon_site ! gC/m2
+
+       ! Add the instantaneous amount of carbon in the accumulated NPP pool, which at this
+       ! model timestep has not been allocated to a FATES biomass pool
+       ! (but will be at the end of the day)
        fates_total_carbon(c) =  fates_total_carbon(c) + this%fates(nc)%bc_out(s)%npp_acc_site
-       
-       write(*,*) 'in fates utils',c,nep(c),nbp(c),fates_total_carbon(c) 
+
     end do
 
     call c2g( bounds = bounds_clump, &
@@ -2976,7 +2978,6 @@ module CLMFatesInterfaceMod
             garr = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds_clump%begg:bounds_clump%endg), &
             c2l_scale_type = 'unity', &
             l2g_scale_type = 'unity')
-
 
     end associate
     return

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2969,15 +2969,8 @@ module CLMFatesInterfaceMod
        ! Add the instantaneous amount of carbon in the accumulated NPP pool, which at this
        ! model timestep has not been allocated to a FATES biomass pool
        ! (but will be at the end of the day)
-       fates_total_carbon(c) =  fates_total_carbon(c) + this%fates(nc)%bc_out(s)%npp_acc_site
 
     end do
-
-    call c2g( bounds = bounds_clump, &
-            carr = soilbiogeochem_carbonflux_inst%fates_nbp_col(bounds_clump%begc:bounds_clump%endc), &
-            garr = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds_clump%begg:bounds_clump%endg), &
-            c2l_scale_type = 'unity', &
-            l2g_scale_type = 'unity')
 
     end associate
     return

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -255,6 +255,7 @@ module CLMFatesInterfaceMod
       procedure, public :: wrap_btran
       procedure, public :: wrap_drydep      
       procedure, public :: wrap_photosynthesis
+      procedure, public :: wrap_atmosphericCarbonFluxes
       procedure, public :: wrap_accumulatefluxes
       procedure, public :: prep_canopyfluxes
       procedure, public :: wrap_canopy_radiation
@@ -272,7 +273,6 @@ module CLMFatesInterfaceMod
       procedure, public  :: wrap_hydraulics_drive
       procedure, public  :: WrapUpdateFatesRmean
       procedure, public  :: wrap_WoodProducts
-      procedure, public  :: wrap_FatesAtmosphericCarbonFluxes
       procedure, public  :: WrapGlobalSeedDispersal
       procedure, public  :: WrapUpdateFatesSeedInOut
       procedure, public  :: UpdateCLitterFluxes
@@ -2920,52 +2920,59 @@ module CLMFatesInterfaceMod
  
 ! ======================================================================================
 
- subroutine wrap_FatesAtmosphericCarbonFluxes(this, bounds_clump, fc, filterc,cnveg_carbonflux_inst)
+ subroutine wrap_atmosphericCarbonFluxes(this,nc,bounds_clump,soilbiogeochem_carbonflux_inst,c_products_inst)
 
    ! summarize the high-level fluxes that integrate information from both
    ! FATES and outside-of-FATES decomposition and product decay code.
-   
+   use subgridAveMod                      , only: c2g
    use FatesConstantsMod     , only : g_per_kg
-   use CNVegCarbonFluxType                , only : cnveg_carbonflux_type
-
-    ! !ARGUMENTS:
-   class(hlm_fates_interface_type), intent(inout) :: this
-   type(bounds_type)              , intent(in)    :: bounds_clump
-   integer                        , intent(in)    :: fc                   ! size of column filter
-   integer                        , intent(in)    :: filterc(fc)          ! column filter
-   type(cnveg_carbonflux_type) , intent(inout) ::   cnveg_carbonflux_inst
    
-   ! Locacs
-   integer                                        :: g,s,c,icc
-   integer                                        :: nc
+   ! !ARGUMENTS:
+   type(bounds_type),  intent(in)             :: bounds_clump
+   class(hlm_fates_interface_type), intent(inout) :: this
+   integer, intent(in) :: nc   
+   type(soilbiogeochem_carbonflux_type), intent(in) :: soilbiogeochem_carbonflux_inst
+   type(cn_products_type)         , intent(inout) :: c_products_inst
+   
+   integer                                        :: g,s,c
 
+   ! NEP, NEE and NBP are outputs
+   ! product loss, hr and fire are inputs. 
    associate(&
-        nep     => cnveg_carbonflux_inst%nep_col    , &
-        nee     => cnveg_carbonflux_inst%nee_grc    , &
-        nbp     => cnveg_carbonflux_inst%nbp_grc    )
-        !product_closs => cnveg_carbonflux_inst%product_closs ,  &
-        !hr     => cnveg_carbonflux_inst%hr)
+        nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
+        nee     => soilbiogeochem_carbonflux_inst%fates_nee_col    , &
+        nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
+        product_closs => c_products_inst%product_loss_grc ,  &   ! Gridcell level product C loss from all pools. gC/m2/s
+        hr     => soilbiogeochem_carbonflux_inst%hr_col) 
 
     do s = 1, this%fates(nc)%nsites
        c = this%f2hmap(nc)%fcolumn(s)
        g = col%gridcell(c)    
-
+     
        nep(c) = this%fates(nc)%bc_out(s)%gpp_site*g_per_kg &
-            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg !&
-  !          - hr(c)
+            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg &
+            - hr(c)
 
-       !nbp(c) = nep(c) &
-!            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
-!            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
-!            - product_closs(c)
+       write(*,*) ' product_closs', c,g !, product_closs(g)
+       nbp(c) = nep(c) &
+            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
+            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg !&
+ !           - product_closs(g)
 
        nee(c) = -nbp(c)
-
     end do
+
+    call c2g( bounds = bounds_clump, &
+            carr = soilbiogeochem_carbonflux_inst%fates_nbp_col(bounds_clump%begc:bounds_clump%endc), &
+            garr = soilbiogeochem_carbonflux_inst%fates_nbp_grc(bounds_clump%begg:bounds_clump%endg), &
+            c2l_scale_type = 'unity', &
+            l2g_scale_type = 'unity')
+
 
     end associate
     return
-  end subroutine wrap_FatesAtmosphericCarbonFluxes
+  end subroutine wrap_atmosphericCarbonFluxes
+  
 
   ! ======================================================================================     
 
@@ -3578,6 +3585,7 @@ module CLMFatesInterfaceMod
 
         select case(trim(ioname))
         case(site_r8)
+
            call hist_addfld1d(fname=trim(vname),units=trim(vunits),         &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=fates_hist%hvars(ivar)%r81d,      &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -95,6 +95,7 @@ module CLMFatesInterfaceMod
    use atm2lndType       , only : atm2lnd_type
    use SurfaceAlbedoType , only : surfalb_type
    use SolarAbsorbedType , only : solarabs_type
+   use CNVegCarbonFluxType             , only : cnveg_carbonflux_type
    use SoilBiogeochemCarbonFluxType, only :  soilbiogeochem_carbonflux_type
    use SoilBiogeochemCarbonStateType, only : soilbiogeochem_carbonstate_type
    use SoilBiogeochemNitrogenFluxType, only :  soilbiogeochem_nitrogenflux_type
@@ -2920,7 +2921,7 @@ module CLMFatesInterfaceMod
  
 ! ======================================================================================
 
- subroutine wrap_atmosphericCarbonFluxes(this,nc,bounds_clump,soilbiogeochem_carbonflux_inst,c_products_inst)
+ subroutine wrap_atmosphericCarbonFluxes(this,bounds_clump,soilbiogeochem_carbonflux_inst,cnveg_carbonflux_inst,c_products_inst)
 
    ! summarize the high-level fluxes that integrate information from both
    ! FATES and outside-of-FATES decomposition and product decay code.
@@ -2930,21 +2931,22 @@ module CLMFatesInterfaceMod
    ! !ARGUMENTS:
    type(bounds_type),  intent(in)             :: bounds_clump
    class(hlm_fates_interface_type), intent(inout) :: this
-   integer, intent(in) :: nc   
+   integer  :: nc   
    type(soilbiogeochem_carbonflux_type), intent(in) :: soilbiogeochem_carbonflux_inst
    type(cn_products_type)         , intent(inout) :: c_products_inst
-   
+   type(cnveg_carbonflux_type)    , intent(inout) :: cnveg_carbonflux_inst
    integer                                        :: g,s,c
 
    ! NEP, NEE and NBP are outputs
    ! product loss, hr and fire are inputs. 
    associate(&
-        nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
-        nee     => soilbiogeochem_carbonflux_inst%fates_nee_col    , &
+        nep     => cnveg_carbonflux_inst%nep_col    , &
         nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
         product_closs => c_products_inst%product_loss_grc ,  &   ! Gridcell level product C loss from all pools. gC/m2/s
         hr     => soilbiogeochem_carbonflux_inst%hr_col) 
 
+    nc = bounds_clump%clump_index
+     
     do s = 1, this%fates(nc)%nsites
        c = this%f2hmap(nc)%fcolumn(s)
        g = col%gridcell(c)    
@@ -2953,13 +2955,11 @@ module CLMFatesInterfaceMod
             - this%fates(nc)%bc_out(s)%ar_site*g_per_kg &
             - hr(c)
 
-       write(*,*) ' product_closs', c,g !, product_closs(g)
        nbp(c) = nep(c) &
             - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
             - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg !&
  !           - product_closs(g)
 
-       nee(c) = -nbp(c)
     end do
 
     call c2g( bounds = bounds_clump, &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2922,7 +2922,7 @@ module CLMFatesInterfaceMod
  
 ! ======================================================================================
 
- subroutine wrap_atmosphericCarbonFluxes(this,bounds_clump,soilbiogeochem_carbonflux_inst,cnveg_carbonflux_inst,c_products_inst)
+ subroutine wrap_atmosphericCarbonFluxes(this,bounds_clump,soilbiogeochem_carbonflux_inst,cnveg_carbonflux_inst)
 
    ! summarize the high-level fluxes that integrate information from both
    ! FATES and outside-of-FATES decomposition and product decay code.
@@ -2933,33 +2933,32 @@ module CLMFatesInterfaceMod
    type(bounds_type),  intent(in)             :: bounds_clump
    class(hlm_fates_interface_type), intent(inout) :: this
    integer  :: nc   
-   type(soilbiogeochem_carbonflux_type), intent(in) :: soilbiogeochem_carbonflux_inst
-   type(cn_products_type)         , intent(inout) :: c_products_inst
-   type(cnveg_carbonflux_type)    , intent(inout) :: cnveg_carbonflux_inst
-   integer                                        :: g,s,c
+   type(soilbiogeochem_carbonflux_type), intent(in)    :: soilbiogeochem_carbonflux_inst
+   type(cnveg_carbonflux_type)         , intent(inout) :: cnveg_carbonflux_inst
+   integer          :: g,s,c
 
    ! NEP, NEE and NBP are outputs
    ! product loss, hr and fire are inputs. 
    associate(&
         nep     => soilbiogeochem_carbonflux_inst%fates_nep_col    , &
         nbp     => soilbiogeochem_carbonflux_inst%fates_nbp_col    , &    
-        product_closs => c_products_inst%product_loss_grc ,  &   ! Gridcell level product C loss from all pools. gC/m2/s
+        product_closs => soilbiogeochem_carbonflux_inst%fates_product_loss_grc ,  &
         hr     => soilbiogeochem_carbonflux_inst%hr_col) 
 
     nc = bounds_clump%clump_index
-     
+
     do s = 1, this%fates(nc)%nsites
        c = this%f2hmap(nc)%fcolumn(s)
        g = col%gridcell(c)    
-     
-       nep(c) = this%fates(nc)%bc_out(s)%gpp_site*g_per_kg &
-            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg &
-            - hr(c)
+
+       ! Instantaneous site level NPP is calculate in FATES in AccumulateFluxes_ED
+       nep(c) = this%fates(nc)%bc_out(s)%npp_site - hr(c) 
+       ! hr should already by in g/m2/s 
 
        nbp(c) = nep(c) &
             - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
-            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg !&
- !           - product_closs(g)
+            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
+           - product_closs(g)
 
     end do
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -272,6 +272,7 @@ module CLMFatesInterfaceMod
       procedure, public  :: wrap_hydraulics_drive
       procedure, public  :: WrapUpdateFatesRmean
       procedure, public  :: wrap_WoodProducts
+      procedure, public  :: wrap_FatesAtmosphericCarbonFluxes
       procedure, public  :: WrapGlobalSeedDispersal
       procedure, public  :: WrapUpdateFatesSeedInOut
       procedure, public  :: UpdateCLitterFluxes
@@ -2917,7 +2918,56 @@ module CLMFatesInterfaceMod
    return
  end subroutine wrap_WoodProducts
  
- ! ======================================================================================
+! ======================================================================================
+
+ subroutine wrap_FatesAtmosphericCarbonFluxes(this, bounds_clump, fc, filterc)
+
+   ! summarize the high-level fluxes that integrate information from both
+   ! FATES and outside-of-FATES decomposition and product decay code.
+   
+   use FatesConstantsMod     , only : g_per_kg
+   use cnveg_carbonfluxMod   , only : cnveg_carbonflux_inst
+   ! !ARGUMENTS:
+   class(hlm_fates_interface_type), intent(inout) :: this
+   type(bounds_type)              , intent(in)    :: bounds_clump
+   integer                        , intent(in)    :: fc                   ! size of column filter
+   integer                        , intent(in)    :: filterc(fc)          ! column filter
+   
+   ! Locacs
+   integer                                        :: s,c,icc
+   integer                                        :: nc
+
+   associate(&
+        nep     => col_cf%nep    , &
+        nee     => col_cf%nee    , &
+        nbp     => cnveg_carbonflux_inst%nbp_grc col_cf%nbp    , &
+        product_closs => col_cf%product_closs ,  &
+        hr     => col_cf%hr)
+ 
+    nc = bounds_clump%clump_index
+    ! Loop over columns
+    do icc = 1,fc
+       c = filterc(icc)
+       s = this%f2hmap(nc)%hsites(c)
+
+       nep(c) = this%fates(nc)%bc_out(s)%gpp_site*g_per_kg &
+            - this%fates(nc)%bc_out(s)%ar_site*g_per_kg &
+            - hr(c)
+
+       nbp(c) = nep(c) &
+            - this%fates(nc)%bc_out(s)%grazing_closs_to_atm_si*g_per_kg &
+            - this%fates(nc)%bc_out(s)%fire_closs_to_atm_si*g_per_kg &
+            - product_closs(c)
+
+       nee(c) = -nbp(c)
+
+    end do
+
+    end associate
+    return
+  end subroutine wrap_FatesAtmosphericCarbonFluxes
+
+  ! ======================================================================================     
 
  subroutine wrap_canopy_radiation(this, bounds_clump, nc, fcansno, surfalb_inst)
 
@@ -3632,7 +3682,7 @@ module CLMFatesInterfaceMod
     integer :: s
     integer :: c
     integer :: l
-    integer :: nc
+    integer :: n
     integer :: num_filter_fates
     integer :: nlevsoil
 


### PR DESCRIPTION
### NOT READY

### Description of changes

 These changes introduce the capability for FATES to write NBP (net biome productivity) fluxes to the atmosphere, inclusive of fire, harvest, grazing and product pool decay carbon flux.

This PR is linked to the FATES-side PR xxx 

**Noting that this code neither creates nor passes the gridcell level balance check on account of timestepping complexities that need to be resolved in a later PR., likely #137** 

To recall: 
**_NBP =.NEP - C_fire - C_grazing - C_productdecay_** 

where fire and grazing fluxes are now output from FATES, and product decay (a gridcell property) is calculated in CTSM. 

NEP is the Net Ecosystem Productivity, defined as 
**_NEP = GPP - Reco_**

where **_GPP_** is the gross photosynthetic productivity and **_Reco_** is total ecosystem respiration inclusive of plant (Rauto) and soil (Rh) 

This code adds

A new wrap function (wrap_atmosphericfluxes) in clmfates_interfacemod.
A set of 'composite' fluxes defined in soilbiogeochemistrycarbonfluxesmod, to be used when FATES is active. These are in addition to those that are defined in cnvegcarbonfluxmod, but those are complicated to use when FATES is on as their history is not defined and they are not accessiable upstream of CNvegetationfacade (or, at least, I couldn't figure this out, yet. I might still try to move them).

### Specific notes

Contributors other than yourself, if any:
@ckoven 
@maritsandstad 
@mvdebolskiy 
@rgknox


CTSM Issues Fixed (include github issue #):
https://github.com/NGEET/fates/issues/163

Are answers expected to change (and if so in what way)?
This should not chance answers EXCEPT for the addition of the new NBP output variable, and the FCO2 flux variable which was peviously zero. 

Any User Interface Changes (namelist or namelist defaults changes)?
no

Does this create a need to change or add documentation? Did you do so?
Maybe? 

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
