### PR TITLE
Fix to grazing flux accumulation

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2940,9 +2940,12 @@ module CLMFatesInterfaceMod
       ! hr_col is updated above this call in CNDriver summaries
       ! these -should- all be in gC/m2/s
       net_carbon_exchange_col(c) = this%fates(ci)%bc_out(s)%npp_site - &
-                                   this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si + &
-                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_si - &
+                                   (this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si + &
+                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_si) * g_per_kg - &
                                    soilbiogeochem_carbonflux_inst%hr_col(c)
+
+      this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si = 0.0_r8 ! zero for the next timestep
+      this%fates(ci)%bc_out(s)%fire_closs_to_atm_si = 0.0_r8
    end do
    call c2g( bounds = bounds_clump, &
          carr = net_carbon_exchange_col(bounds_clump%begc:bounds_clump%endc), &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2941,7 +2941,7 @@ module CLMFatesInterfaceMod
       ! these -should- all be in gC/m2/s
       net_carbon_exchange_col(c) = this%fates(ci)%bc_out(s)%npp_site - &
                                    this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si + &
-                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_sig - &
+                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_si - &
                                    soilbiogeochem_carbonflux_inst%hr_col(c)
    end do
    call c2g( bounds = bounds_clump, &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2938,9 +2938,10 @@ module CLMFatesInterfaceMod
       s = this%f2hmap(ci)%hsites(c)
       ! nbp = npp -fire - graz - soil respiratation
       ! hr_col is updated above this call in CNDriver summaries
+      ! these -should- all be in gC/m2/s
       net_carbon_exchange_col(c) = this%fates(ci)%bc_out(s)%npp_site - &
-                                   (this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si + &
-                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_si) * g_per_kg - &
+                                   this%fates(ci)%bc_out(s)%grazing_closs_to_atm_si + &
+                                   this%fates(ci)%bc_out(s)%fire_closs_to_atm_sig - &
                                    soilbiogeochem_carbonflux_inst%hr_col(c)
    end do
    call c2g( bounds = bounds_clump, &


### PR DESCRIPTION
### Description of changes
This PR brings in a fix to the accumulation of grazing and fire fluxes, which are both accumulated over cohorts (grazing) and patches (fire) but not actually zeroed between timesteps. This caused significant outgassing from the land. 

### Specific notes
The addition of the zeroing statement into clmfates_interfaceMod means that it is zeroed immediatley after it is used. There was no general location for zeroing these types of accumulating site-level fluxes in the FATES code. But maybe this should actually be on the FATES side? 

Also noting that the FATES team are working on this sort of thing in tandem, so this may become depracated eventually. 

Contributors other than yourself, if any:
@maritsandstad 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Yes, but only for FCO2

Any User Interface Changes (namelist or namelist defaults changes)?
No

Does this create a need to change or add documentation? Did you do so?
No

Testing performed, if any:
None as yet. noting that for FCO2, this variable is not output by default, and so it is possible that we are not testing it. 
Making it active by default would be good, but I am not sure that this won't generate issues wrt the variable not being allocated under different conditions. @maritsandstad @mvdebolskiy maybe we should bring in a change to this as a different PR? What do you think? 

