### PR TITLE
Update to spitfire 4 and medlyn stomatal model

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2408,9 +2408,9 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 <!-- ===== FATES DEFAULTS =========== -->
 <fates_electron_transport_model use_fates=".true.">FvCB1980</fates_electron_transport_model>
 <fates_photosynth_acclimation   use_fates=".true.">nonacclimating</fates_photosynth_acclimation>
-<fates_spitfire_mode            use_fates=".true.">4</fates_spitfire_mode>
+<fates_spitfire_mode            use_fates=".true.">1</fates_spitfire_mode>
 <fates_harvest_mode             use_fates=".true.">no_harvest</fates_harvest_mode>
-<fates_stomatal_model           use_fates=".true.">ballberry1987</fates_stomatal_model>
+<fates_stomatal_model           use_fates=".true.">medlyn2011</fates_stomatal_model>
 <fates_stomatal_assimilation    use_fates=".true.">net</fates_stomatal_assimilation>
 <fates_leafresp_model           use_fates=".true.">ryan1991</fates_leafresp_model>
 <fates_cstarvation_model        use_fates=".true.">linear</fates_cstarvation_model>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2410,7 +2410,7 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 <fates_photosynth_acclimation   use_fates=".true.">nonacclimating</fates_photosynth_acclimation>
 <fates_spitfire_mode            use_fates=".true.">4</fates_spitfire_mode>
 <fates_harvest_mode             use_fates=".true.">no_harvest</fates_harvest_mode>
-<fates_stomatal_model           use_fates=".true.">medlyn2011</fates_stomatal_model>
+<fates_stomatal_model           use_fates=".true.">ballberry1987</fates_stomatal_model>
 <fates_stomatal_assimilation    use_fates=".true.">net</fates_stomatal_assimilation>
 <fates_leafresp_model           use_fates=".true.">ryan1991</fates_leafresp_model>
 <fates_cstarvation_model        use_fates=".true.">linear</fates_cstarvation_model>

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -701,8 +701,9 @@ contains
                    write(iulog,*)'qflx_glcice_dyn_water_flux = ', qflx_glcice_dyn_water_flux_col(indexc)*dtime
               end if
               
-              write(iulog,*)'CTSM is stopping'
-              call endrun(subgrid_index=indexc, subgrid_level=subgrid_level_column, msg=errmsg(sourcefile, __LINE__))
+              write(iulog,*) 'CTSM should have stopped! Commented out for testing purposes.'
+              !   write(iulog,*)'CTSM is stopping'
+              !   call endrun(subgrid_index=indexc, subgrid_level=subgrid_level_column, msg=errmsg(sourcefile, __LINE__))
          end if
        
        end if
@@ -786,8 +787,9 @@ contains
              write(iulog,*)'forc_flood                = ',forc_flood_grc(indexg)*dtime
              write(iulog,*)'qflx_glcice_dyn_water_flux = ',qflx_glcice_dyn_water_flux_grc(indexg)*dtime
 
-             write(iulog,*)'CTSM is stopping'
-             call endrun(subgrid_index=indexg, subgrid_level=subgrid_level_gridcell, msg=errmsg(sourcefile, __LINE__))
+!             write(iulog,*)'CTSM is stopping'
+!             call endrun(subgrid_index=indexg, subgrid_level=subgrid_level_gridcell, msg=errmsg(sourcefile, __LINE__))
+             write(iulog,*)'CTSM should have stopped! Commented out for testing purposes.'
           end if
 
        end if


### PR DESCRIPTION
### Description of changes
This PR makes a branch with updated land defaults for use in the coupled NorESM PPE. Spitfire is set to 4 ( use external lightning and population datasets to simulate both natural and anthropogenic ignitions.) and we make the Medlyn stomatal model the default. 
Endrun statements for water balance are converted to warnings. 

### Specific notes

Contributors other than yourself, if any:
@rosiealice @kjetilaas @maritsandstad 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Yes - changes stomatal model and fire model behaviour. 

Any User Interface Changes (namelist or namelist defaults changes)?
Yes - see above changes to namelist options. 

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any:
No testing yet. Will be tested together with FATES side branch for the PPE. 

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
