### PR TITLE
Fix path to mizuroute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,8 +58,8 @@ fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/MOSART
 
 [submodule "mizuRoute"]
-	path = components/mizuroute
-	url = https://github.com/ESCOMP/mizuRoute
+path = components/mizuroute
+url = https://github.com/ESCOMP/mizuRoute
 fxtag = cesm-coupling.n03_v2.2.0
 fxrequired = ToplevelRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed


### PR DESCRIPTION
Needed, so git-fleximod CI tests do not give warnings.