### PR TITLE
ctsm5.4.002_noresm_v4: Update fates to sci5_api1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 [submodule "fates"]
 path = src/fates
 url = https://github.com/NorESMhub/fates
-fxtag = sci.1.88.6_api.42.0.0_nor_sci2_api1
+fxtag = sci.1.88.6_api.42.0.0_nor_sci5_api1
 fxrequired = AlwaysRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/NorESMhub/fates

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -4857,6 +4857,17 @@
       <option name="comment">""</option>
     </options>
   </test>
+
+  <test name="ERS_Ld11_P1536" grid="ne30pg3_ne30pg3_mtn14" compset="I1850Clm60FatesNocompSpinup" testmods="clm/FatesIniSpinup">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_clm_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:50:00</option>
+      <option name="comment">""</option>
+    </options>
+  </test>
+
   <test name="SMS_D_Ld1000_P1536" grid="ne30pg3_ne30pg3_mtn14" compset="I1850Clm60FatesNocompSpinup" testmods="clm/FatesColdSpinup">
     <machines>
       <machine name="betzy" compiler="gnu" category="aux_clm_noresm"/>

--- a/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/shell_commands
@@ -1,0 +1,8 @@
+./xmlchange DATM_CPLHIST_CASE=n1850fates-nocomp-cplhist
+./xmlchange DATM_CPLHIST_DIR='/cluster/shared/noresm/inputdata/cplhist/noresm3_0/n1850fates-nocomp-cplhist/cpl/hist'
+./xmlchange DATM_YR_START=1
+./xmlchange DATM_YR_END=1
+./xmlchange DATM_YR_ALIGN=1
+./xmlchange DATM_PRESNDEP=none
+./xmlchange LND_TUNING_MODE="clm6_0_cam7.0"
+./xmlchange ROF_NCPL='$ATM_NCPL'

--- a/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_clm
@@ -1,3 +1,3 @@
 use_fates_fixed_biogeog = .true.
 fates_radiation_model='twostream'
-finidat='/cluster/work/users/mdeb/noresm/ne30ini/n1850.ne30pg3_tn14.noresm3_0_beta10-run8_yr121.20260131.clm2.r.0151-01-01-00000.nc'
+finidat='$DIN_LOC_ROOT/lnd/clm2/initdata_esmf/ctsm5.4/n1850.ne30pg3_tn14.noresm3_0_beta10_beta_testing_20260131.nc'

--- a/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_clm
@@ -1,0 +1,3 @@
+use_fates_fixed_biogeog = .true.
+fates_radiation_model='twostream'
+finidat='/cluster/work/users/mdeb/noresm/ne30ini/n1850.ne30pg3_tn14.noresm3_0_beta10-run8_yr121.20260131.clm2.r.0151-01-01-00000.nc'

--- a/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_datm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesIniSpinup/user_nl_datm
@@ -1,0 +1,3 @@
+iradsw = -1
+nextsw_cday_calc = "cam7"
+


### PR DESCRIPTION
### Description of changes

Update fates submodule with the following prs merged:

NorESMhub/fates#49
NorESMhub/fates#50
NorESMhub/fates#54

### Specific notes

Added an ERS test where FATES starts from an initial dataset.


Contributors other than yourself, if any: @maritsandstad @rgknox @mvertens @rosiealice @JessicaNeedham 

CTSM Issues Fixed (include github issue #):

#200 
NorESMhub/NorESM#770

Are answers expected to change (and if so in what way)?

Yes. 

Any User Interface Changes (namelist or namelist defaults changes)?

No, apart from one fates history variable

Does this create a need to change or add documentation? Did you do so?

No

Testing performed, if any:

aux_clm_noresm: PASS
ERS_Ld10.ne30pg3_ne30pg3_mtn14.NF1850fates-nocomp.betzy_intel.cam-outfrq9s_fatesini now also passes.
