### PR TITLE
ctsm5.4.002_noresm_v6: fix for year-boundary restart issue

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1881,9 +1881,6 @@ module CLMFatesInterfaceMod
       ! I think that is it...
       ! ---------------------------------------------------------------------------------
 
-      ! Set the FATES global time and date variables
-      call GetAndSetTime
-
       if(.not.initialized) then
 
          initialized=.true.
@@ -2016,6 +2013,11 @@ module CLMFatesInterfaceMod
       ! ---------------------------------------------------------------------------------
 
       if(flag=='read')then
+        ! pass time to FATES internal variables
+        ! since this routine is called on 'define','write','read'
+        ! and the first two can be called whenever, calling this outside 'read'
+        ! will change the time that has been previously set in dynamics_driver
+        call GetAndSetTime
 
          !$OMP PARALLEL DO PRIVATE (nc,bounds_clump,s)
          do nc = 1, nclumps


### PR DESCRIPTION
### Description of changes

Move clm-2-fates time passing in the fates restart routine to `flag='read'` condition

### Specific notes

Contributors other than yourself, if any:

@monsieuralok @rosiealice @mvertens @maritsandstad 

CTSM Issues Fixed (include github issue #):

NorESMhub/NorESM#790

Are answers expected to change (and if so in what way)?

Yes, when running with writing out restarts.

Any User Interface Changes (namelist or namelist defaults changes)?

No

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any:

```
aux_clm_noresm PASS
prealpha_noresm PASS
```
baselines BFB.