### PR TITLE
Fix/root sink transpiration balance

### DIFF
--- a/src/biogeophys/SoilWaterPlantSinkMod.F90
+++ b/src/biogeophys/SoilWaterPlantSinkMod.F90
@@ -166,6 +166,7 @@ contains
       integer :: pi
       integer :: p
       real(r8) :: temp(bounds%begc:bounds%endc)                         ! accumulator for rootr weighting
+      real(r8) :: sink_sum
 
 
       associate(& 
@@ -226,6 +227,17 @@ contains
               end if
               qflx_rootsoi_col(c,j) = rootr_col(c,j)*qflx_tran_veg_col(c)
            end do
+        end do
+
+        ! Gentle rescale: rescale root sink if needed for water balance consistency
+        do fc = 1, num_filterc
+           c = filterc(fc)
+           sink_sum = sum(qflx_rootsoi_col(c,:))
+           if (sink_sum > 1.e-16_r8 .and. abs(sink_sum - qflx_tran_veg_col(c)) > 1.e-14_r8) then
+              do j = 1, nlevsoi
+                 qflx_rootsoi_col(c,j) = qflx_rootsoi_col(c,j) * qflx_tran_veg_col(c) / sink_sum
+              end do
+           end if
         end do
       end associate
       return
@@ -360,6 +372,7 @@ contains
     integer  :: p,c,fc,j                                              ! do loop indices
     integer  :: pi                                                    ! patch index
     real(r8) :: temp(bounds%begc:bounds%endc)                         ! accumulator for rootr weighting
+    real(r8) :: sink_sum
     associate(& 
           qflx_rootsoi_col    => waterfluxbulk_inst%qflx_rootsoi_col    , & ! Output: [real(r8) (:,:) ]  
                                                                         ! vegetation/soil water exchange (m H2O/s) (+ = to atm)
@@ -418,6 +431,17 @@ contains
             qflx_rootsoi_col(c,j) = rootr_col(c,j)*qflx_tran_veg_col(c)
 
          end do
+      end do
+
+      ! Gentle rescale: rescale root sink if needed for water balance consistency
+      do fc = 1, num_filterc
+         c = filterc(fc)
+         sink_sum = sum(qflx_rootsoi_col(c,:))
+         if (sink_sum > 1.e-16_r8 .and. abs(sink_sum - qflx_tran_veg_col(c)) > 1.e-14_r8) then
+            do j = 1, nlevsoi
+               qflx_rootsoi_col(c,j) = qflx_rootsoi_col(c,j) * qflx_tran_veg_col(c) / sink_sum
+            end do
+         end if
       end do
     end associate
     return

--- a/src/biogeophys/SoilWaterPlantSinkMod.F90
+++ b/src/biogeophys/SoilWaterPlantSinkMod.F90
@@ -166,7 +166,6 @@ contains
       integer :: pi
       integer :: p
       real(r8) :: temp(bounds%begc:bounds%endc)                         ! accumulator for rootr weighting
-      real(r8) :: sink_sum
 
 
       associate(& 
@@ -204,8 +203,10 @@ contains
               c = filterc(fc)
               do p = col%patchi(c), col%patchi(c) + col%npatches(c) - 1
                  if (patch%active(p)) then
-                    rootr_col(c,j) = rootr_col(c,j) + rootr_patch(p,j) * &
-                          qflx_tran_veg_patch(p) * patch%wtcol(p)
+                    if (sum(rootr_patch(p,:)) > 0._r8) then
+                       rootr_col(c,j) = rootr_col(c,j) + rootr_patch(p,j) * &
+                             qflx_tran_veg_patch(p) * patch%wtcol(p)
+                    end if
                  end if
               end do
            end do
@@ -214,7 +215,9 @@ contains
            c = filterc(fc)
            do p = col%patchi(c), col%patchi(c) + col%npatches(c) - 1
               if (patch%active(p)) then
-                 temp(c) = temp(c) + qflx_tran_veg_patch(p) * patch%wtcol(p)
+                 if (sum(rootr_patch(p,:)) > 0._r8) then
+                    temp(c) = temp(c) + qflx_tran_veg_patch(p) * patch%wtcol(p)
+                 end if
               end if
            end do
         end do
@@ -229,16 +232,6 @@ contains
            end do
         end do
 
-        ! Gentle rescale: rescale root sink if needed for water balance consistency
-        do fc = 1, num_filterc
-           c = filterc(fc)
-           sink_sum = sum(qflx_rootsoi_col(c,:))
-           if (sink_sum > 1.e-16_r8 .and. abs(sink_sum - qflx_tran_veg_col(c)) > 1.e-14_r8) then
-              do j = 1, nlevsoi
-                 qflx_rootsoi_col(c,j) = qflx_rootsoi_col(c,j) * qflx_tran_veg_col(c) / sink_sum
-              end do
-           end if
-        end do
       end associate
       return
    end subroutine Compute_EffecRootFrac_And_VertTranSink_HydStress_Roads
@@ -372,7 +365,6 @@ contains
     integer  :: p,c,fc,j                                              ! do loop indices
     integer  :: pi                                                    ! patch index
     real(r8) :: temp(bounds%begc:bounds%endc)                         ! accumulator for rootr weighting
-    real(r8) :: sink_sum
     associate(& 
           qflx_rootsoi_col    => waterfluxbulk_inst%qflx_rootsoi_col    , & ! Output: [real(r8) (:,:) ]  
                                                                         ! vegetation/soil water exchange (m H2O/s) (+ = to atm)
@@ -407,8 +399,10 @@ contains
             c = filterc(fc)
             do p = col%patchi(c), col%patchi(c) + col%npatches(c) - 1
                if (patch%active(p)) then
-                  rootr_col(c,j) = rootr_col(c,j) + rootr_patch(p,j) * &
-                        qflx_tran_veg_patch(p) * patch%wtcol(p)
+                  if (sum(rootr_patch(p,:)) > 0._r8) then
+                     rootr_col(c,j) = rootr_col(c,j) + rootr_patch(p,j) * &
+                           qflx_tran_veg_patch(p) * patch%wtcol(p)
+                  end if
                end if
             end do
          end do
@@ -417,7 +411,9 @@ contains
          c = filterc(fc)
          do p = col%patchi(c), col%patchi(c) + col%npatches(c) - 1
             if (patch%active(p)) then
-               temp(c) = temp(c) + qflx_tran_veg_patch(p) * patch%wtcol(p)
+               if (sum(rootr_patch(p,:)) > 0._r8) then
+                  temp(c) = temp(c) + qflx_tran_veg_patch(p) * patch%wtcol(p)
+               end if
             end if
          end do
       end do
@@ -433,16 +429,6 @@ contains
          end do
       end do
 
-      ! Gentle rescale: rescale root sink if needed for water balance consistency
-      do fc = 1, num_filterc
-         c = filterc(fc)
-         sink_sum = sum(qflx_rootsoi_col(c,:))
-         if (sink_sum > 1.e-16_r8 .and. abs(sink_sum - qflx_tran_veg_col(c)) > 1.e-14_r8) then
-            do j = 1, nlevsoi
-               qflx_rootsoi_col(c,j) = qflx_rootsoi_col(c,j) * qflx_tran_veg_col(c) / sink_sum
-            end do
-         end if
-      end do
     end associate
     return
  end subroutine Compute_EffecRootFrac_And_VertTranSink_Default


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

Below is the code claude generated about this issue, which passes the balance check in the https://github.com/NorESMhub/CTSM/issues/229 in the setup that Jessie's script here:
creates (which I adapted to make it not hit permissions errors). 
https://github.com/JessicaNeedham/FATES-testing-scripts/blob/main/create_fates_h2o_dumpinfo.sh

This current code passed the water balance error with DEBUG off, but no with it on. Actively working on this now, so consider this very much as a draft. 

**Summary**
This PR adds a guard in SoilWaterPlantSinkMod so that _only_ patches with **nonzero** roots contribute to transpiration-weighted root sink aggregation.

**Why this change is needed**
The column-level effective root fraction (rootr_col) and its weighting denominator (temp) are built from patch-level transpiration-weighted terms.
If active patches with **zero root profile** are included in these weighted sums, they can influence sink weighting in a physically inconsistent way and contribute to water-balance instability.

**This PR makes that weighting explicitly root-aware.**

What this PR changes
File:

src/biogeophys/SoilWaterPlantSinkMod.F90
Routines:

Compute_EffecRootFrac_And_VertTranSink_HydStress_Roads
Compute_EffecRootFrac_And_VertTranSink_Default
In both routines, patch contributions are now included only when:

sum(rootr_patch(p,:)) > 0._r8
This condition is applied in both places that define the weighting:

Accumulation of rootr_col(c,j)
Accumulation of temp(c)
Behavioral intent

Ensure transpiration-weighted sink distribution uses only rooted patches.
Prevent rootless active patches from biasing root-fraction weighting.
Keep the change physically based and localized


<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

<!-- Description goes here -->

### Specific notes

**Contributors other than yourself, if any:**
- (Replace this text and add more list items as needed)

**CTSM issues resolved or otherwise addressed, if any:**
- (Replace this text, including GitHub issue #, and add more list items as needed)
<!-- Put each issue on its own line, like "Resolves #3986" or "Contributes to #3151". -->
<!-- "Resolves" is a magic word; see them all at https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue -->

**If answers are expected to change, describe (delete this line otherwise):**

**Any user interface changes (namelist or namelist defaults changes)?**

**Testing planned or performed, if any:**
- [ ] (Replace this text and add more list items as needed)
<!-- (List what testing you did to show your changes worked as expected) -->



### Requirements before merge:
- [ ] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
<!-- Delete all list items below if this PR is purely Tech Note and/or User's Guide updates -->
- [ ] The code in this PR branch builds with no errors.
- [ ] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):**
- [ ] This either (a) does not change answers, (b) it only changes answers at roundoff level, or (c) I have performed a scientific evaluation of the answer changes. **Which?:**
<!-- If (c) above, include your analyses in the "Description of changes" section. -->
- [ ] I have reviewed relevant parts of the CLM documentation [Tech Note](https://escomp.github.io/CTSM/tech_note/index.html) or [User's Guide](https://escomp.github.io/CTSM/users_guide/index.html) to determine if anything needs to be changed or added. **If it does, describe:**
- [ ] This PR either (a) does not create a need to update the documentation or (b) includes required documentation updates (see [guidelines for contributing documentation](https://escomp.github.io/CTSM/users_guide/working-with-documentation/docs-intro.html#contribution-guidelines)). **Which?:**
