### PR TITLE
Parameter updates and partial fixes for historical simulations.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 [submodule "fates"]
 path = src/fates
 url = https://github.com/NorESMhub/fates
-fxtag = sci.1.92.5_api.46.0.0_nor_sci4_api2
+fxtag = sci.1.92.5_api.46.0.0_nor_sci5_api2
 fxrequired = AlwaysRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/NorESMhub/fates

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2749,6 +2749,7 @@ sub setup_logic_initial_conditions {
         $finidat = $finidatf;
         add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
                 $var, 'val'=>$finidatf);
+         $nl_flags->{'excess_ice_on_finidat'} = $nl_flags->{'use_excess_ice'};
      } else { 
         add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
                 $var, 'val'=>"' '", 'no_abspath'=>1);
@@ -5346,7 +5347,7 @@ sub setup_logic_exice_streams {
   # Checking for cold clm_start_type and not finidat here since finidat can be not set set in branch/hybrid runs and
   # These cases are handled in the restart routines in the model
   } elsif ( defined($use_exice_streams) && (not value_is_true($use_exice_streams)) && value_is_true($use_exice) &&
-          ( $nl_flags->{'clm_start_type'} eq "'cold'" || $nl_flags->{'clm_start_type'} eq "'arb_ic'" )) {
+          ( $nl_flags->{'clm_start_type'} eq "'cold'" || ($nl_flags->{'clm_start_type'} eq "'arb_ic'" && string_is_undef_or_empty($finidat)))) {
      $log->fatal_error("use_excess_ice_streams can NOT be FALSE when use_excess_ice is TRUE on the cold start" );
   }
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -609,7 +609,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- CLM parameter files (relative to {csmdata}) -->
 <paramfile phys="clm6_0">lnd/clm2/paramdata/ctsm60_params.c260518.nc</paramfile>
 <paramfile phys="clm6_0" esm="cesm">lnd/clm2/paramdata/ctsm60_params.c260518.nc</paramfile>
-<paramfile phys="clm6_0" use_fates=".true." esm="noresm">lnd/clm2/paramdata/ctsm60_params.noresm.c260508.nc</paramfile>
+<paramfile phys="clm6_0" use_fates=".true." esm="noresm">lnd/clm2/paramdata/ctsm60_params.noresm.c260611.nc</paramfile>
 <paramfile phys="clm6_0" esm="cesm" lnd_tuning_mode="clm6_0_cam7.0">lnd/clm2/paramdata/ctsm60-cam70_params.c260518.nc</paramfile>
 <paramfile phys="clm6_0" use_hillslope=".true.">lnd/clm2/paramdata/ctsm60-HH_params.c260518.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c260305.nc</paramfile>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -365,7 +365,7 @@
   </compset>
 
   <compset>
-    <alias>NHISTClm60Fates</alias>
+    <alias>NIHISTClm60Fates</alias>
     <lname>HIST_DATM%CRUJRA2024b_CLM60%FATES%NORESM_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

Update to `paramfile`
Update to fates tag with new `fates_param_file`
Fix for constantly running exice streams read with fates on

### Specific notes

**Contributors other than yourself, if any:**
- (Replace this text and add more list items as needed)


**If answers are expected to change, describe (delete this line otherwise):**
Yes
**Any user interface changes (namelist or namelist defaults changes)?**
See description
**Testing planned or performed, if any:**
- [x] aux_clm_noresm betzy
  - Expected DIFF for all NorESM compsets
  - Expected NLFAIL for all non-NorESM compsets
- [x] aux_clm_noresm olivia
  - Expected DIFF for all NorESM compsets
  - Expected NLFAIL for all non-NorESM compsets
  - Expected fail for 2 tests:
    - 1850Clm60NorSpinup.betzy_intel.clm-FatesNoresmSpinupAllVars
    - ERI_Ld9.f45_f45_mg37.I2000Clm60BgcCrop.olivia_intel.clm-default
  - NOTE: "SMS_D.ne16pg3_ne16pg3_mtn14.NIHISTClm60FatesSp.olivia_gnu.clm-FatesColdSatPhen" is marked as expected fail, but passes (DIFF)
 
